### PR TITLE
abort request upon timeout instead of retrying

### DIFF
--- a/utils/RequestQueue.h
+++ b/utils/RequestQueue.h
@@ -72,12 +72,14 @@ protected:
             this->bActive = true;
             this->processRequest(queue[iOutIndex]);
         } else if (TIMEOUT && getTime() - timeOf[iOutIndex] > TIMEOUT) {
+            this->abortRequest(queue[iOutIndex]);
             // update timing to reflect restart
             for (auto index = iOutIndex; index != iInIndex; inc(index)) {
                 timeOf[index] = getTime();
             }
             // restart
-            this->processRequest(queue[iOutIndex]);
+//            this->processRequest(queue[iOutIndex]);
+            endProcess();
         }
         return ret;
     }
@@ -159,6 +161,11 @@ protected:
      * process a given request
      */
     virtual void processRequest(Request &) = 0;
+
+    /**
+     * abort a failed (e.g. timed-out) request
+     */
+    virtual void abortRequest(Request &) { };
 
     /**
      * get current time in ms


### PR DESCRIPTION
this will need some more thought.

it _does_ make more sense not to keep retrying the same thing over and over again though, especially without resetting things first.
maybe aborting, and _then_ retrying would be the way?

or best yet: just notify the user of the abort, let them decide how to handle it.

this did make working with the ultrasonic sensors easier though.