### PR TITLE
check for experiment active during init

### DIFF
--- a/utils/Experiment.h
+++ b/utils/Experiment.h
@@ -112,6 +112,8 @@ public:
                 // state machine
                 if (!init) {
                     this->eState = RUN;
+                } else if (!this->bExperimentActive) {
+                    this->eState = STOP;
                 }
                 break;
             case RUN:


### PR DESCRIPTION
while working on the mobrost trailer system i realised, that if some module's `init()` depends on some external event which will not happen, it is impossible to get out of the INIT state again, even when stopping the experiment from pywisp.

this commit makes it impossible to get stuck in init state by checking for the active bit as well.