### PR TITLE
I2c device

### DIFF
--- a/sensors/ADS1115.h
+++ b/sensors/ADS1115.h
@@ -21,7 +21,7 @@
  * http://www.ti.com/lit/ds/symlink/ads1115.pdf
  * for details
  */
-class ADS1115 {
+class ADS1115 : I2CDevice {
 private:
     ///\cond false
     enum {
@@ -85,9 +85,9 @@ public:
     ///\cond false
     // single conversion mode
     bool single = false;
-    bool cMod = 0;
-    bool cPol = 0;
-    bool cLat = 0;
+    bool cMod = false;
+    bool cPol = false;
+    bool cLat = false;
     uint8_t cQue = 0;
     ///\endcond
 
@@ -100,8 +100,8 @@ public:
      */
     ADS1115(uint8_t address = 0b1001000, enum range fs = FS6144,
             enum dataRate dr = SPS64, enum mux mx = AIN0):
-                eFullScale(fs), eDataRate(dr),
-                eMux(mx), address(address) {
+                I2CDevice(address), eFullScale(fs),
+                eDataRate(dr), eMux(mx) {
         updateConfig();
     }
 
@@ -141,42 +141,42 @@ public:
 
 private:
     ///\cond false
-    uint8_t address;
     uint8_t buffer[2] = {};
 
     void setPointer(uint8_t reg) {
-        I2CRequest point (
-                address,
+        HardwareI2C::master()->request(new I2CRequest(
+                this,
                 0,
                 &reg,
                 1,
                 I2CRequest::I2C_DIRECT_WRITE,
-                nullptr);
-        HardwareI2C::master()->request(point);
+                nullptr)
+        );
     }
 
     void read() {
-        I2CRequest meas (
-                address,
+        HardwareI2C::master()->request(new I2CRequest(
+                this,
                 0,
                 buffer,
                 2,
                 I2CRequest::I2C_DIRECT_READ,
-                nullptr);
-        HardwareI2C::master()->request(meas);
+                nullptr)
+        );
     }
 
     void write(uint8_t reg, uint16_t val) {
-        uint8_t data[3] = {reg, (uint8_t)(val>>8), (uint8_t)val};
-        I2CRequest write (
-                address,
+        uint8_t data[3] = {reg, (uint8_t) (val >> 8), (uint8_t) val};
+        HardwareI2C::master()->request(new I2CRequest(
+                this,
                 0,
                 data,
                 3,
                 I2CRequest::I2C_DIRECT_WRITE,
-                nullptr);
-        HardwareI2C::master()->request(write);
+                nullptr)
+        );
     }
     ///\endcond
 };
+
 #endif //ADS1115_H

--- a/sensors/AS5145.h
+++ b/sensors/AS5145.h
@@ -10,7 +10,7 @@
 /**
  * Class describing a chain of AS5145 Hall sensors
  */
-class HallSensor : public ChipSelect {
+class AS5145 : ChipSelect {
 private:
     ///\cond false
     // sensor data struct. lsb to msb order.
@@ -37,7 +37,7 @@ public:
      * @param port GPIO port of chip select line
      * @param n     number of sensors attached to daisy-chain
      */
-    HallSensor(uint32_t pin, GPIO_TypeDef *port, int n) : ChipSelect(pin, port),
+    AS5145(uint32_t pin, GPIO_TypeDef *port, int n) : ChipSelect(pin, port),
             BUFLEN((n * NUMBITS) / 8UL + (n * NUMBITS % 8 ? 1 : 0)) // calculate bytes needed for n sensors
             {
         buffer = new uint8_t[BUFLEN]();
@@ -57,8 +57,14 @@ public:
      * request measurement of sensor data
      */
     void sense() {
-        SPIRequest r = {this, SPIRequest::MISO, nullptr, buffer, BUFLEN, (void *)true};
-        HardwareSPI::master()->request(r);
+        HardwareSPI::master()->request(new SPIRequest(
+                this,
+                SPIRequest::MISO,
+                nullptr,
+                buffer,
+                BUFLEN,
+                (void *)true)
+        );
     }
 
     ///\cond false

--- a/sensors/MAX31855.h
+++ b/sensors/MAX31855.h
@@ -10,7 +10,7 @@
 
 #include "stm/spi.h"
 
-class MAX31855 : public ChipSelect {
+class MAX31855 : ChipSelect {
 public:
     /**
      * Constructor
@@ -41,8 +41,14 @@ public:
      * request measurement of sensor data
      */
     void sense() {
-        SPIRequest r = {this, SPIRequest::MISO, nullptr, buffer, sizeof(buffer), (void*)true};
-        HardwareSPI::master()->request(r);
+        HardwareSPI::master()->request(new SPIRequest(
+                this,
+                SPIRequest::MISO,
+                nullptr,
+                buffer,
+                sizeof(buffer),
+                (void*)true)
+        );
     }
 
     ///\cond false

--- a/stm/i2c.h
+++ b/stm/i2c.h
@@ -187,7 +187,7 @@ private:
         if (r.cbData) {
             r.dev->callback(r.cbData);
         }
-        // signal request complete
+        // signal request completion
         pThis->rqEnd();
     }
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(QueueTest RequestQueueTest.cpp)
 target_compile_definitions(QueueTest PUBLIC BOOST_TEST_DYN_LINK)
 target_include_directories(QueueTest PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(QueueTest ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-add_test(NAME singleRequestTest COMMAND QueueTest)
+add_test(NAME QueueTest COMMAND QueueTest)
 
 add_executable(MATest MovingAverageTest.cpp)
 target_compile_definitions(MATest PUBLIC BOOST_TEST_DYN_LINK)


### PR DESCRIPTION
implement `I2CDevice` class to make implementing new i2c devices easier.

this enables us to use a generic callback upon request completion, like the SPI driver has had for some time.

this branch also changes the `RequestQueue` to work with pointers to requests instead of requests themselves.
Users of the queue will now have to push  heap-allocated requests into the queue, it will free them after they are completed.
```c++
    queue->request(new MyRequest( ... ));
```
* updated sensors:
  - [x] ADS1115
  - [x] AS5145
  - [x] IMU3000
  - [x] MAX31855
  - [x] MAX31865
* tested and works:
  - [x] ADS1115
  - [x] AS5145
  - [x] IMU3000
  - [x] MAX31855
  - [x] MAX31865