### PR TITLE
hw continuation

### DIFF
--- a/sensors/AS5145.h
+++ b/sensors/AS5145.h
@@ -14,18 +14,15 @@ class AS5145 : ChipSelect {
 private:
     ///\cond false
     // sensor data struct. lsb to msb order.
-    union SensorData {
-        struct __packed  {
-            uint8_t EVEN: 1;
-            uint8_t DEC: 1;
-            uint8_t INC: 1;
-            uint8_t LIN: 1;
-            uint8_t COF: 1;
-            uint8_t OCF: 1;
-            uint16_t POS: 12;
-            uint8_t : 1;
-        };
-        uint32_t u32;
+    struct __packed SensorData {
+        uint8_t EVEN:1;
+        uint8_t DEC:1;
+        uint8_t INC:1;
+        uint8_t LIN:1;
+        uint8_t COF:1;
+        uint8_t OCF:1;
+        uint16_t POS:12;
+        uint8_t :1;
     } *sensor = nullptr;
     const unsigned short NUMBITS = 19;  // number of bits in sensor data struct
     uint8_t *buffer = nullptr;          // temporary data buffer
@@ -77,13 +74,7 @@ public:
      * copy data from buffer into struct.
      */
     void callback(void *cbData) override {
-        flip(buffer, BUFLEN);
-
-        for (int i = 0; i < num; ++i) {
-            uint8_t off = (i+1)*NUMBITS;
-            sensor[i].u32 = *(uint32_t *)&buffer[BUFLEN-1 - off/8] >> (8 - off%8);
-        }
-//        bitwisecopy((uint8_t *)sensor, NUMBITS, sizeof(*sensor), buffer, num);
+        bitwisecopy((uint8_t *)sensor, NUMBITS, sizeof(*sensor), buffer, num);
     }
     ///\endcond
 };

--- a/sensors/AS5145.h
+++ b/sensors/AS5145.h
@@ -13,6 +13,7 @@
 class AS5145 : ChipSelect {
 private:
     ///\cond false
+    RequestQueue<SPIRequest> *bus;
     // sensor data struct. lsb to msb order.
     struct __packed SensorData {
         uint8_t EVEN:1;
@@ -21,7 +22,7 @@ private:
         uint8_t LIN:1;
         uint8_t COF:1;
         uint8_t OCF:1;
-        uint16_t POS:12;
+        int16_t POS:12;
         uint8_t :1;
     } *sensor = nullptr;
     const unsigned short NUMBITS = 19;  // number of bits in sensor data struct
@@ -33,11 +34,12 @@ private:
 public:
     /**
      * Constructor
-     * @param pin GPIO pin of chip select line
-     * @param port GPIO port of chip select line
-     * @param n     number of sensors attached to daisy-chain
+     * @param bus SPI bus
+     * @param cs ChipSelect pin
+     * @param n number of sensors attached to daisy-chain
      */
-    AS5145(uint32_t pin, GPIO_TypeDef *port, int n) : ChipSelect(pin, port),
+    AS5145(RequestQueue<SPIRequest> *bus, DIO cs, int n) : ChipSelect(cs),
+            bus(bus),
             BUFLEN((n * NUMBITS) / 8UL + (n * NUMBITS % 8 ? 1 : 0)) // calculate bytes needed for n sensors
             {
         buffer = new uint8_t[BUFLEN]();
@@ -49,7 +51,7 @@ public:
      * @param i index of sensor in chain
      * @return measured sensor angle
      */
-    double getAngle(int i = 0) {
+    int16_t getVal(int i = 0) {
         return sensor[i].POS;
     }
 
@@ -57,13 +59,13 @@ public:
      * request measurement of sensor data
      */
     void sense() {
-        HardwareSPI::master()->request(new SPIRequest(
+        bus->request(new SPIRequest{
                 this,
                 SPIRequest::MISO,
                 nullptr,
                 buffer,
                 BUFLEN,
-                (void *)true)
+                (void *)true}
         );
     }
 
@@ -74,7 +76,7 @@ public:
      * copy data from buffer into struct.
      */
     void callback(void *cbData) override {
-        bitwisecopy((uint8_t *)sensor, NUMBITS, sizeof(*sensor), buffer, num);
+        bitwisecopy((uint8_t *)sensor, buffer, NUMBITS, num);
     }
     ///\endcond
 };

--- a/stm/pwm.h
+++ b/stm/pwm.h
@@ -6,6 +6,7 @@
 #define STM_PWM_H
 
 #include "stm/hal.h"
+#include "stm/timer.h"
 
 /**
  * @brief Template class for hardware based PWM outputs
@@ -17,19 +18,27 @@ public:
      * @param perc [0..1]
      */
     void pwm(double perc) {
-        __HAL_TIM_SET_COMPARE(hTim, channel, perc * period);
+        ticks(perc * period);
     }
+
+    /**
+     * set pwm as value of timer ticks
+     * @param ticks
+     */
+     void ticks(uint32_t ticks) {
+         __HAL_TIM_SET_COMPARE(hTim, channel, ticks);
+     }
 
     /**
      * Initialize Timer Channel
      *
      * make sure to initialize the corresponding AFIO pin
      *
-     * @param hTim handle of configured HardwareTimer
+     * @param tim pointer to HardwareTimer
      * @param chan timer channel number (TIM_CHANNEL_x)
      */
-    HardwarePWM(TIM_HandleTypeDef *hTim, uint32_t chan) :
-            hTim(hTim), channel(chan), period(hTim->Init.Period) {
+    HardwarePWM(HardwareTimer *tim, uint32_t chan) :
+            hTim(tim->handle()), channel(chan), period(hTim->Init.Period) {
         // pwm config of timer
         while (HAL_TIM_PWM_Init(hTim) != HAL_OK);
 

--- a/stm/spi.h
+++ b/stm/spi.h
@@ -2,23 +2,6 @@
  *
  * Copyright (c) 2019 IACE
  *
- **********************************************
- * When using this, use the following line in your interrupt header
- * file (e.g. `stm32f7xx_it.h`):
- *
- *      extern SPI_HandleTypeDef hHWSPI;
- *
- * and put the following interrupt handler in your interrupt implementation
- * file (e.g. `stm32f7xx_it.c`)
- *
- * (**attention**: configure the correct SPI peripheral according to your
- * defined HW_SPI):
- *
- *      void SPI3_IRQHandler(void) {
- *          HAL_SPI_IRQHandler(&hHWSPI);
- *      }
- *
- **********************************************
  */
 
 #ifndef STM_SPI_H
@@ -54,12 +37,8 @@ class ChipSelect {
     DIO pin;
     //\endcond
 public:
-    /**
-     * @param iCSPIN chip select pin number
-     * @param gpioCSPort chip select pin port
-     */
-    ChipSelect(uint32_t iCSPIN, GPIO_TypeDef *gpioCSPort) :
-            pin(iCSPIN, gpioCSPort) {
+    ChipSelect(DIO cs) :
+            pin(cs) {
         this->selectChip(false);
     }
 
@@ -81,8 +60,7 @@ public:
  * struct defining an SPI request.
  * use this when requesting data from the \ref HardwareSPI
  */
-class SPIRequest {
-public:
+struct SPIRequest {
     ChipSelect *cs;     ///< pointer the \ref ChipSelect instance requesting data
     /// direction the data should travel
     enum eDir {
@@ -94,30 +72,6 @@ public:
     uint8_t *rData;     ///< pointer to receive buffer
     uint32_t dataLen;   ///< number of bytes to transfer
     void *cbData;     ///< data to use in callback
-
-    /**
-     * @param cs
-     * @param dir
-     * @param tData
-     * @param rData
-     * @param dataLen
-     * @param cbData
-     */
-    SPIRequest(ChipSelect *cs, enum eDir dir, uint8_t *tData, uint8_t *rData,
-            uint32_t dataLen, void *cbData) :
-            cs(cs), dir(dir), tData(tData), rData(rData),
-            dataLen(dataLen), cbData(cbData) {
-    }
-
-    ~SPIRequest() {
-        tData = nullptr;
-        cs = nullptr;
-        dir = MOSI;
-        tData = nullptr;
-        rData = nullptr;
-        dataLen = 0;
-        cbData = nullptr;
-    }
 };
 
 /**

--- a/utils/RequestQueue.h
+++ b/utils/RequestQueue.h
@@ -82,6 +82,7 @@ protected:
      */
     short rqAdd(Request *r) {
         if (bFull) {
+            delete r;
             return -1;
         }
         queue[iInIndex] = r;


### PR DESCRIPTION
this adds SPI to the things that 'just work' with the interface thingie.

also makes AS5145 usable on different SPI busses.

also adds a 'ticks' method to the `HardwarePWM`, which helps with doing things like rc servos (e.g. ntrailer)

finally fix a memory leak in the requestqueue that used to happen when it was full and could not accept new requests.

