### PR TITLE
assert: make impl work with std cassert header

### DIFF
--- a/linux/host.cpp
+++ b/linux/host.cpp
@@ -24,10 +24,6 @@ void Kernel::idle() {
     this->tick(dt.count());
 }
 
-void assert(bool b) {
-    if (!b) abort();
-}
-
 void sighandler(int signum);
 
 struct impl {

--- a/stm/hal.cpp
+++ b/stm/hal.cpp
@@ -10,8 +10,9 @@ void HAL_IncTick() {
     k.tick(uwTickFreq);
     uwTick += uwTickFreq;
 }
-void assert(bool b) {
-    if (!b) asm("bkpt");
+void __assert_func(const char *file, int line, const char *func, const char *assert) {
+    asm("bkpt");
+    while (true);
 }
 
 extern "C" {

--- a/utils/buffer.h
+++ b/utils/buffer.h
@@ -5,7 +5,7 @@
 #pragma once
 #include <cstring>
 #include <cstdint>
-extern void assert(bool);
+#include <cassert>
 
 /**
  * dynamically allocated, but fixed-size buffer template


### PR DESCRIPTION
this fixes an issue when trying to use the tool-libs' Buffer with e.g. pybind11