### PR TITLE
series: updates

### DIFF
--- a/comm/series.h
+++ b/comm/series.h
@@ -5,22 +5,21 @@
 #pragma once
 #include "frameregistry.h"
 /** unpacking helper for data series sent from pywisp */
+template<typename T, int FRAMELEN=80>
 struct SeriesUnpacker {
-    size_t bsize {40};
+    static constexpr size_t LEN = FRAMELEN / sizeof(T);
     bool start {true};
-    Buffer<double> buf;
+    Buffer<T> buf;
 
     /** call this with incoming frames until it returns
      * a Buffer filled with the data sent over the wire
      */
-    Buffer<double> *unpack(Frame &f) {
-        unsigned int LEN = bsize / 8;
-
+    Buffer<T> *unpack(Frame &f) {
         if (start) {
             buf = f.unpack<uint32_t>();
         }
         for (unsigned int i = 0; i < LEN - start; i++) {
-            buf.append(f.unpack<double>());
+            buf.append(f.unpack<T>());
             if (buf.len == buf.size) {
                 start = true;
                 return &buf;


### PR DESCRIPTION
- allow arbitrary types to be unpacked
- let framelength be compile-time constant

fixes #62
TODO: update framelength both here and on pywisp side to make full use of packets (INT8_MAX)