### PR TITLE
fix deadline generation for i2c & spi peripherals

### DIFF
--- a/stm/i2c.cpp
+++ b/stm/i2c.cpp
@@ -7,10 +7,12 @@ namespace debug {
 namespace i2c {
 }}
 using namespace I2C;
-static Deadline until(size_t datasize) {
+namespace I2C {
+Deadline until(size_t datasize) {
     constexpr uint32_t cpms = 100000 / 1000; // fixed at 100kHz, noone is going slower
     uint32_t ret = (datasize+1)*9/cpms;
     return {ret?ret:2}; // allow minimum of 2ms
+}
 }
 
 void _startMaster(HW *i2c) {

--- a/stm/spi.cpp
+++ b/stm/spi.cpp
@@ -5,8 +5,10 @@
 #include "spi.h"
 
 using namespace SPI;
-static Deadline until(size_t datasize) {
+namespace SPI {
+Deadline until(size_t datasize) {
     return {};
+}
 }
 
 void switchmode(HW *spi, Device::Conf newconf) {


### PR DESCRIPTION
bfca0a8 didn't actually hide the functions, just the issue, silently linking in the first function it finds. This commit instead puts the functions in their respective namespaces.