### PR TITLE
clean up child process on segmentation fault

### DIFF
--- a/linux/host.cpp
+++ b/linux/host.cpp
@@ -61,6 +61,7 @@ struct impl {
         act.sa_handler = sighandler;
         sigfillset(&act.sa_mask);
         sigaction(SIGINT, &act, NULL);
+        sigaction(SIGSEGV, &act, NULL);
     }
     ~impl() {
         if (c_pid) {


### PR DESCRIPTION
previously the communication process would remain active even when the parent ran into an assert