### PR TITLE
split stm targets per peripheral

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 3.24)
-project(tool-libs VERSION 0.2.0 LANGUAGES CXX C ASM)
-cmake_policy(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25)
+cmake_policy(VERSION 3.25)
 
 add_library(tool-libs INTERFACE)
 target_include_directories(tool-libs INTERFACE .)

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_library(tool-libs-linux INTERFACE)
 target_sources(tool-libs-linux INTERFACE host.cpp)
+target_link_libraries(tool-libs-linux INTERFACE tool-libs)

--- a/stm/CMakeLists.txt
+++ b/stm/CMakeLists.txt
@@ -1,7 +1,25 @@
+
 add_library(tool-libs-stm INTERFACE)
-target_sources(tool-libs-stm INTERFACE
-    hal.cpp
-    i2c.cpp
-    spi.cpp
-    uart.cpp
-)
+target_sources(tool-libs-stm INTERFACE hal.cpp)
+target_link_libraries(tool-libs-stm INTERFACE tool-libs)
+target_compile_definitions(tool-libs-stm INTERFACE
+    HAL_TIM_MODULE_ENABLED USE_HAL_TIM_REGISTER_CALLBACKS=1
+    )
+
+add_library(tool-libs-stm-i2c INTERFACE)
+target_sources(tool-libs-stm-i2c INTERFACE i2c.cpp)
+target_link_libraries(tool-libs-stm-i2c INTERFACE tool-libs-stm)
+target_compile_definitions(tool-libs-stm-i2c INTERFACE
+    HAL_I2C_MODULE_ENABLED USE_HAL_I2C_REGISTER_CALLBACKS=1)
+
+add_library(tool-libs-stm-spi INTERFACE)
+target_sources(tool-libs-stm-spi INTERFACE spi.cpp)
+target_link_libraries(tool-libs-stm-spi INTERFACE tool-libs-stm)
+target_compile_definitions(tool-libs-stm-spi INTERFACE
+    HAL_SPI_MODULE_ENABLED USE_HAL_SPI_REGISTER_CALLBACKS=1)
+
+add_library(tool-libs-stm-uart INTERFACE)
+target_sources(tool-libs-stm-uart INTERFACE uart.cpp)
+target_link_libraries(tool-libs-stm-uart INTERFACE tool-libs-stm)
+target_compile_definitions(tool-libs-stm-uart INTERFACE
+    HAL_UART_MODULE_ENABLED USE_HAL_UART_REGISTER_CALLBACKS=1)


### PR DESCRIPTION
also make `-linux` and `-stm{-*}` targets depend on `tool-libs` explicitly, so that the user doesn't have to specify this anymore
**NOTE**: this is somewhat of a breaking change!
you will have to explicitly link to the peripheral you want to use now, similar to how we do it with the stm32-cmake project already.  E.g. to actually use the `UART` peripheral, you now have to link to `tool-libs-stm-uart`. similar targets exist for `i2c` and `spi` for now.

A potential follow-up i'm thinking about would do away with the need to link to both `HAL::STM32::F7::UARTEx` _and_ `tool-libs-stm-uart` with a syntax of e.g. `tool_libs_stm_link(${myexecutable} STM32F767ZI adc spi uart)` or something similar, haven't managed to think it through all the way yet