### PR TITLE
CAN implementation

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -38,6 +38,7 @@ jobs:
           build-base
           doctest-dev
           cmake
+          linux-headers
         arch: ${{ matrix.arch }}
 
     - name: Set reusable strings

--- a/comm/can.h
+++ b/comm/can.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <cstdint>
+#include <core/streams.h>
+namespace CAN {
+struct Message {
+    uint64_t data;
+    uint32_t id;
+    struct {
+        uint8_t rtr:1;
+        uint8_t ide:1;
+        uint8_t dlc:4;
+    } opts;
+};
+
+struct CAN : public Sink<Message>, public Source<Message> { };
+}

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -189,6 +189,7 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
 struct Device : Sink<TPDO>, Sink<SDO> {
     Device(Dispatch &canopen, uint8_t id) : id(id), out(canopen)
     {
+        assert(id > 0 && id < 128);
         canopen.registersdo(id, this);
     }
     uint8_t const id {};    ///< CANOpen node ID [1 - 127]

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -2,6 +2,7 @@
 #include "can.h"
 
 namespace CAN {
+/** cf. https://www.can-cia.org/fileadmin/resources/documents/brochures/co_poster.pdf */
 namespace Open {
 /** CANOpen Service Data Object xfer request
  *
@@ -180,9 +181,9 @@ struct Device : Sink<TPDO>, Sink<SDO> {
         bool waiting{};
     } state;
     /** implement the callback method to handle incoming data */
-    virtual void callback(SDO rq) = 0;
+    virtual void callback(SDO rq) { assert(false); };
     /** implement the callback method to handle incoming data */
-    virtual void callback(TPDO rq) = 0;
+    virtual void callback(TPDO rq) { assert(false); };
     void process() {
         if (state.waiting || state.q.empty()) return;
         out.push(state.q.pop());

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -157,6 +157,17 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
 #endif
         }
     }
+    enum NMT : uint8_t {
+        OPERATIONAL = 1,
+        PREPARED = 2,
+        PREOP = 0x80,
+        RESET = 0x81,
+        RESET_COMM = 0x82,
+    };
+    void nmt(NMT command, uint8_t nodeid) {
+        can.push({.data = (uint64_t)(nodeid & 0x7f) << 8 | command,
+                .id = 0, .opts = {.dlc = 2}});
+    }
 };
 
 /** CANOpen device wrapper class

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -105,7 +105,8 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
     bool handlePDO(Message msg) {
         for (int i = 0; i < pdo.n; ++i) {
             auto tpdo = pdo.pdo[i];
-            if (tpdo->COB == msg.id) {
+            if (tpdo->COB == msg.id
+                    && msg.opts.dlc) {
                 tpdo->data = msg.data;
                 pdo.dev[i]->push(*tpdo);
                 return true;

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -56,7 +56,7 @@ struct PDOMap {
     uint8_t len;
     int32_t data;
 };
-enum PDOType : uint8_t { SYNC, CHANGE=255 };
+enum PDOType : uint8_t { SYNC, CYCLIC=254, CHANGE=255 };
 /** CANOpen Receive Process Data Object Type */
 struct RPDO {
     uint8_t N;
@@ -80,8 +80,8 @@ struct RPDO {
 struct TPDO {
     uint8_t N;
     PDOType type;
-    uint32_t COB; // CAN OBject ID
-    /* uint64_t data; */
+    uint32_t COB; ///< CAN OBject ID
+    uint32_t inhibit_time; ///< inhibit time in 0.1ms steps
     Buffer<PDOMap> map;
     void setData(uint64_t d) {
         uint8_t shift = 0;
@@ -280,7 +280,7 @@ struct Device : Sink<TPDO>, Sink<SDO> {
         if (pdo.COB == 0) pdo.COB = id + 0x80 + 0x100 * pdo.N;
         disablepdo(pdo);
         w8(0x1800+pdo.N-1, 0x2, pdo.type);
-        /* w16(0x1800+pdo.N-1, 0x3, pdo.inhibit_time); */
+        w16(0x1800+pdo.N-1, 0x3, pdo.inhibit_time);
         /* w16(0x1800+pdo.N-1, 0x5, pdo.event_timer); */
         w8(0x1a00+pdo.N-1, 0x0, 0); // clear number of mapped objects
         for (size_t i = 0; i < pdo.map.len; ++i) {

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -16,16 +16,9 @@ struct SDO {
     uint8_t nodeID; ///< node ID of device
 
     Message toCanMsg() {
-        uint32_t id{};
-        uint8_t len{};
-        switch (cmd>>4 & 0xf) {
-        case 0x2: id = nodeID + 0x600; len = 8; break;
-        /* case 0x4: id = nodeID + 0x580; len = 4; break; */
-        case 0x4: id = nodeID + 0x600; len = 8; break;
-        }
         return {
             .data = cmd | ix << 8 | sub << 24 | (uint64_t)data << 32,
-            .id = id,
+            .id = (uint32_t)0x600 + nodeID,
             .opts = { .rtr = 0, .ide = 0, .dlc = 8},
         };
     }

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -17,9 +17,9 @@ enum class NMT : uint8_t {
 };
 /** CANOpen Device states */
 enum class STATE : uint8_t {
-    STOPPED = 4,
-    OPERATIONAL = 5,
-    PREOP = 0x7f,
+    STOPPED = 4,        ///< STOPPED
+    OPERATIONAL = 5,    ///< OPERATIONAL
+    PREOP = 0x7f,       ///< PRE-OPERATIONAL
 };
 /** CANOpen Service Data Object xfer request
  *
@@ -33,14 +33,14 @@ struct SDO {
     uint8_t cmd;    ///< type of request
     uint8_t nodeID; ///< node ID of device
 
-    Message toCanMsg() {
+    Message toMessage() {
         return {
             .data = cmd | ix << 8 | sub << 24 | (uint64_t)data << 32,
             .id = (uint32_t)0x600 + nodeID,
             .opts = { .rtr = 0, .ide = 0, .dlc = 8},
         };
     }
-    static SDO fromCanMsg(Message msg) {
+    static SDO fromMessage(Message msg) {
         return {
             .data = (uint32_t)(msg.data >> 32),
             .ix = (uint16_t)(msg.data >> 8),
@@ -50,40 +50,43 @@ struct SDO {
         };
     }
 };
+/** Single Entry in PDO Data List */
 struct PDOMap {
-    uint16_t ix;
-    uint8_t sub;
-    uint8_t len;
-    int32_t data;
+    uint16_t ix;    ///< index of Data Object
+    uint8_t sub;    ///< subindex of Data Object
+    uint8_t len;    ///< length of object [bits] {8, 16, 32}
+    int32_t data;   ///< received data // data to send
 };
-enum PDOType : uint8_t { SYNC, CYCLIC=254, CHANGE=255 };
+/** Type of PDO transmission */
+enum PDOType : uint8_t {
+    SYNC,       ///< synchronous == on every NMT SYNC message
+    CYCLIC=254, ///< cyclic == after inhibit_time
+    CHANGE=255, ///< change == ASAP on change of parameters
+};
 /** CANOpen Receive Process Data Object Type */
 struct RPDO {
-    uint8_t N;
-    PDOType type;
-    uint32_t COB {}; // CAN OBject ID
-    Buffer<PDOMap> map;
-    Message write(uint64_t data) const {
-        return {.data=data, .id = COB, .opts = {.dlc=8}};
-    }
-    Message write() const {
-        uint64_t dat = 0;
+    uint8_t N;              ///< Index of PDO [1 .. x]
+    PDOType type;           ///< reception type
+    uint32_t COB {};        ///< CAN OBject ID -- leave empty for defaults
+    Buffer<PDOMap> map;     ///< PDO Data Map
+    Message toMessage() const {
+        uint64_t data = 0;
         uint8_t shift = 0;
         for (auto &i : map) {
-            dat |= (i.data & ((uint64_t)1 << i.len)-1) << shift;
+            data |= (i.data & ((uint64_t)1 << i.len)-1) << shift;
             shift += i.len;
         }
-        return {.data=dat, .id = COB, .opts = {.dlc=(uint8_t)(shift / 8)}};
+        return {.data=data, .id = COB, .opts = {.dlc=(uint8_t)(shift / 8)}};
     }
 };
 /** CANOpen Transmit Process Data Object Type */
 struct TPDO {
-    uint8_t N;
-    PDOType type;
-    uint32_t COB; ///< CAN OBject ID
-    uint32_t inhibit_time; ///< inhibit time in 0.1ms steps
-    Buffer<PDOMap> map;
-    void setData(uint64_t d) {
+    uint8_t N;              ///< Index of PDO [1 .. x]
+    PDOType type;           ///< transmission type
+    uint32_t COB {};        ///< CAN OBject ID -- leave empty for defaults
+    uint32_t inhibit_time;  ///< inhibit time in 0.1ms steps
+    Buffer<PDOMap> map;     ///< PDO Data Map
+    void receive(uint64_t d) {
         uint8_t shift = 0;
         for (auto &i : map) {
             i.data = d >> shift & ((uint64_t)1 << i.len) - 1;
@@ -99,6 +102,7 @@ struct TPDO {
  * call this class' `process` directly after the CAN irqHandler
  *
  * cf. https://www.microcontrol.net/wp-content/uploads/2021/10/td-03011e.pdf
+ *
  * cf. https://www.can-cia.org/fileadmin/resources/documents/brochures/co_poster.pdf
  */
 struct Dispatch : Sink<SDO>, Sink<Message> {
@@ -111,64 +115,24 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
         uint8_t n {};
     } pdo;
 
-    using Sink<SDO>::push;
-    void push(SDO &&rq) override {
-        //assert(ids[rq.nodeID] != nullptr); //must register first!
-        if (ids[rq.nodeID] ==nullptr) {
-            k.log.warn("ID [0x%x] NOT registered!\n", rq.nodeID);
-            return;
-        }
-        can.push(rq.toCanMsg());
+    /** send NMT command to nodeid, rsp broadcast it (id = 0) */
+    void nmt(NMT command, uint8_t nodeid) {
+        can.push({.data = (uint64_t)(nodeid & 0x7f) << 8 | (uint8_t)command,
+                .id = 0, .opts = {.dlc = 2}});
     }
-    using Sink<Message>::push;
-    void push(Message &&rq) override { can.push(rq); }
-
-    void registersdo(uint16_t nodeID, Sink<SDO> *dev) {
-        assert(nodeID != 0);
-        assert(ids[nodeID] == nullptr);
-        ids[nodeID] = dev;
+    /** send SYNC message on network */
+    void sync() {
+        can.push({.id = 0x80, .opts = {.dlc = 0}});
     }
-    void registerpdo(TPDO *tpdo, Sink<TPDO> *dev) {
-        assert ( pdo.n < 8 );
-        pdo.dev[pdo.n] = dev;
-        pdo.pdo[pdo.n] = tpdo;
-        pdo.n += 1;
+    /** send HEARTBEAT message to node id, signal own state */
+    void heartbeat(uint8_t id, STATE state) {
+        can.push({.data = (uint8_t)state, .id = (uint32_t)0x700 + id, .opts = {.dlc = 1}});
     }
-
-    bool handlePDO(Message msg) {
-        for (int i = 0; i < pdo.n; ++i) {
-            auto tpdo = pdo.pdo[i];
-            if (tpdo->COB == msg.id
-                    && msg.opts.dlc) {
-                tpdo->setData(msg.data);
-                pdo.dev[i]->push(*tpdo);
-	    /* k.log.info("handled PDO id: %x\n", msg.id); */
-	    /* k.log.info("          data: %x\n", msg.data); */
-	    /* k.log.info("    TPDO data0: %x\n",tpdo->map[0].data); */
-	    /* k.log.info("    TPDO data1: %x\n",tpdo->map[1].data); */
-                return true;
-            }
-        }
-        return false;
+    /** send GUARD message to node id */
+    void guard(uint8_t id) {
+        can.push({.id = (uint32_t)0x700 + id, .opts = {.rtr = true}});
     }
-    bool handleSDO(Message msg) {
-        uint16_t service = msg.id & ~0x7f;
-        uint8_t id = msg.id & 0x7f;
-        if (id == 0) return false;
-        if (//service == 0x80 ||  // SYNC
-            service == 0x580 || // SDO server-to-client
-            //service == 0x600 || // SDO client-to-server
-            //service == 0x700 || // NMT control
-            false) {
-            if (ids[id]) {
-                ids[id]->push(SDO::fromCanMsg(msg));
-            }
-	    /* k.log.info("handled SDO id: %x\n", msg.id); */
-            return true;
-        }
-        return false;
-    }
-
+    /** call directly after CAN interrupt handler processed */
     void process() {
         // TODO: what to do to CAN messages that _aren't_ CanOpen
         while (!can.empty()) {
@@ -202,18 +166,63 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
                     );
         }
     }
-    void nmt(NMT command, uint8_t nodeid) {
-        can.push({.data = (uint64_t)(nodeid & 0x7f) << 8 | (uint8_t)command,
-                .id = 0, .opts = {.dlc = 2}});
+
+    using Sink<SDO>::push;
+    void push(SDO &&rq) override {
+        //assert(ids[rq.nodeID] != nullptr); //must register first!
+        if (ids[rq.nodeID] ==nullptr) {
+            k.log.warn("ID [0x%x] NOT registered!\n", rq.nodeID);
+            return;
+        }
+        can.push(rq.toMessage());
     }
-    void sync() {
-        can.push({.id = 0x80, .opts = {.dlc = 0}});
+    using Sink<Message>::push;
+    void push(Message &&rq) override { can.push(rq); }
+
+    void registerSDO(uint16_t nodeID, Sink<SDO> *dev) {
+        assert(nodeID != 0);
+        assert(ids[nodeID] == nullptr);
+        ids[nodeID] = dev;
     }
-    void heartbeat(uint8_t id, STATE state) {
-        can.push({.data = (uint8_t)state, .id = (uint32_t)0x700 + id, .opts = {.dlc = 1}});
+    void registerPDO(TPDO *tpdo, Sink<TPDO> *dev) {
+        assert ( pdo.n < 8 );
+        pdo.dev[pdo.n] = dev;
+        pdo.pdo[pdo.n] = tpdo;
+        pdo.n += 1;
     }
-    void guard(uint8_t id) {
-        can.push({.id = (uint32_t)0x700 + id, .opts = {.rtr = true}});
+
+    bool handlePDO(Message msg) {
+        for (int i = 0; i < pdo.n; ++i) {
+            auto tpdo = pdo.pdo[i];
+            if (tpdo->COB == msg.id
+                    && msg.opts.dlc) {
+                tpdo->receive(msg.data);
+                pdo.dev[i]->push(*tpdo);
+	    /* k.log.info("handled PDO id: %x\n", msg.id); */
+	    /* k.log.info("          data: %x\n", msg.data); */
+	    /* k.log.info("    TPDO data0: %x\n",tpdo->map[0].data); */
+	    /* k.log.info("    TPDO data1: %x\n",tpdo->map[1].data); */
+                return true;
+            }
+        }
+        return false;
+    }
+    bool handleSDO(Message msg) {
+        uint16_t service = msg.id & ~0x7f;
+        uint8_t id = msg.id & 0x7f;
+        if (id == 0) return false;
+        if (//service == 0x80 ||  // SYNC
+            service == 0x580 || // SDO server-to-client
+            //service == 0x600 || // SDO client-to-server
+            //service == 0x700 || // NMT control
+            false) {
+            if (ids[id]) {
+                ids[id]->push(SDO::fromMessage(msg));
+            }
+	    /* k.log.info("handled SDO id: %x\n", msg.id); */
+            return true;
+        }
+        return false;
     }
 };
 
@@ -222,10 +231,11 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
  * inherit and implement `callback` to use this interface on a CANOpen network
  */
 struct Device : Sink<TPDO>, Sink<SDO> {
+    /** Construct new CANOpen Device on network with given ID */
     Device(Dispatch &canopen, uint8_t id) : id(id), out(canopen)
     {
         assert(id > 0 && id < 128);
-        canopen.registersdo(id, this);
+        canopen.registerSDO(id, this);
     }
     uint8_t const id {};    ///< CANOpen node ID [1 - 127]
     Dispatch &out;
@@ -238,20 +248,6 @@ struct Device : Sink<TPDO>, Sink<SDO> {
     virtual void callback(SDO rq) { assert(false); };
     /** implement the callback method to handle incoming data */
     virtual void callback(TPDO rq) { assert(false); };
-    void process() {
-        if (state.q.empty()) return;
-        if (state.next.when && !state.next(k.time)) return;
-        out.push(state.q.pop());
-        state.next = {k.time + 2};
-    }
-    void pushorqueue(SDO &&sdo) {
-        if (state.next.when && !state.next(k.time)) {
-            state.q.push(std::move(sdo));
-        } else {
-            out.push(std::move(sdo));
-            state.next = {k.time + 2};
-        }
-    }
     /** read DO with given index and subindex of this device */
     void read(uint16_t ix, uint8_t sub) {
         pushorqueue({.ix=ix, .sub=sub, .cmd=0x40, .nodeID=id});
@@ -268,10 +264,14 @@ struct Device : Sink<TPDO>, Sink<SDO> {
     void w32(uint16_t ix, uint8_t sub, uint32_t val) {
         pushorqueue({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x23, .nodeID=id});
     }
+    /** send PDO */
+    void wPDO(const RPDO &rpdo) {
+        out.push(rpdo.toMessage());
+    }
     /** enable receiving PDO on device */
-    void enablepdo(RPDO &pdo) {
+    void enablePDO(RPDO &pdo) {
         if (pdo.COB == 0) pdo.COB = id + 0x100 * (pdo.N+1);
-        disablepdo(pdo);
+        disablePDO(pdo);
         w8(0x1400+pdo.N-1, 0x2, pdo.type); // set transmission type
         w8(0x1600+pdo.N-1, 0x0, 0); // clear number of mapped objects
         for (size_t i = 0; i < pdo.map.len; ++i) {
@@ -281,21 +281,14 @@ struct Device : Sink<TPDO>, Sink<SDO> {
         w8(0x1600+pdo.N-1, 0x0, pdo.map.len); // set number of mapped objects
         w32(0x1400+pdo.N-1, 0x1, 1<<30 | pdo.COB);
     }
-    void disablepdo(RPDO &pdo) {
+    /** disable receiving PDO on device */
+    void disablePDO(RPDO &pdo) {
         w32(0x1400+pdo.N-1, 0x1, 1<<31); // clear
     }
-    /** send data through given pdo */
-    void wpdo(const RPDO &rpdo, int64_t val) {
-        out.push(rpdo.write(val));
-    }
-    /** send data through given pdo */
-    void wpdo(const RPDO &rpdo) {
-        out.push(rpdo.write());
-    }
     /** enable sending PDO on device */
-    void enablepdo(TPDO &pdo) {
+    void enablePDO(TPDO &pdo) {
         if (pdo.COB == 0) pdo.COB = id + 0x80 + 0x100 * pdo.N;
-        disablepdo(pdo);
+        disablePDO(pdo);
         w8(0x1800+pdo.N-1, 0x2, pdo.type);
         w16(0x1800+pdo.N-1, 0x3, pdo.inhibit_time);
         /* w16(0x1800+pdo.N-1, 0x5, pdo.event_timer); */
@@ -306,9 +299,10 @@ struct Device : Sink<TPDO>, Sink<SDO> {
         }
         w8(0x1a00+pdo.N-1, 0x0, pdo.map.len); // set number of mapped objects
         w32(0x1800+pdo.N-1, 0x1, 1<<30 | pdo.COB); // enable PDO
-        out.registerpdo(&pdo, this);
+        out.registerPDO(&pdo, this);
     };
-    void disablepdo(TPDO &pdo) {
+    /** disable sending PDO on device */
+    void disablePDO(TPDO &pdo) {
         w32(0x1800+pdo.N-1, 0x1, 1<<31); // clear
     };
     using Sink<SDO>::push;
@@ -321,6 +315,20 @@ struct Device : Sink<TPDO>, Sink<SDO> {
     void push(TPDO &&pdo) override {
         callback(std::move(pdo));
         process();
+    }
+    void process() {
+        if (state.q.empty()) return;
+        if (state.next.when && !state.next(k.time)) return;
+        out.push(state.q.pop());
+        state.next = {k.time + 2};
+    }
+    void pushorqueue(SDO &&sdo) {
+        if (state.next.when && !state.next(k.time)) {
+            state.q.push(std::move(sdo));
+        } else {
+            out.push(std::move(sdo));
+            state.next = {k.time + 2};
+        }
     }
 };
 }

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -160,6 +160,9 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
         can.push({.data = (uint64_t)(nodeid & 0x7f) << 8 | command,
                 .id = 0, .opts = {.dlc = 2}});
     }
+    void sync() {
+        can.push({.id = 0x80, .opts = {.dlc = 0}});
+    }
 };
 
 /** CANOpen device wrapper class

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -208,25 +208,29 @@ struct Device : Sink<TPDO>, Sink<SDO> {
         out.push(state.q.pop());
         state.next = {k.time + 2};
     }
+    void pushorqueue(SDO &&sdo) {
+        if (state.next.when && !state.next(k.time)) {
+            state.q.push(std::move(sdo));
+        } else {
+            out.push(std::move(sdo));
+            state.next = {k.time + 2};
+        }
+    }
     /** read DO with given index and subindex of this device */
     void read(uint16_t ix, uint8_t sub) {
-        state.q.push({.ix=ix, .sub=sub, .cmd=0x40, .nodeID=id});
-        process();
+        pushorqueue({.ix=ix, .sub=sub, .cmd=0x40, .nodeID=id});
     }
     /** write given value to DO at given index and subindex */
-    void w8(uint16_t ix, uint8_t sub, int8_t val) {
-        state.q.push({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x2f, .nodeID=id});
-        process();
+    void w8(uint16_t ix, uint8_t sub, uint8_t val) {
+        pushorqueue({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x2f, .nodeID=id});
     }
     /** write given value to DO at given index and subindex */
-    void w16(uint16_t ix, uint8_t sub, int16_t val) {
-        state.q.push({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x2b, .nodeID=id});
-        process();
+    void w16(uint16_t ix, uint8_t sub, uint16_t val) {
+        pushorqueue({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x2b, .nodeID=id});
     }
     /** write given value to DO at given index and subindex */
-    void w32(uint16_t ix, uint8_t sub, int32_t val) {
-        state.q.push({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x23, .nodeID=id});
-        process();
+    void w32(uint16_t ix, uint8_t sub, uint32_t val) {
+        pushorqueue({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x23, .nodeID=id});
     }
     /** enable receiving PDO on device */
     void enablepdo(RPDO &pdo) {

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -1,0 +1,242 @@
+#pragma once
+#include "can.h"
+
+namespace CAN {
+namespace Open {
+/** CANOpen Service Data Object xfer request
+ *
+ * this struct shouldn't have to be instantiated by the user directly.
+ * use the helper functions of the Device instead.
+ */
+struct SDO {
+    uint32_t data;  ///< up to 4 bytes of data
+    uint16_t ix;    ///< index of DO
+    uint8_t sub;    ///< subindex of DO
+    uint8_t cmd;    ///< type of request
+    uint8_t nodeID; ///< node ID of device
+
+    Message toCanMsg() {
+        uint32_t id{};
+        uint8_t len{};
+        switch (cmd>>4 & 0xf) {
+        case 0x2: id = nodeID + 0x600; len = 8; break;
+        /* case 0x4: id = nodeID + 0x580; len = 4; break; */
+        case 0x4: id = nodeID + 0x600; len = 8; break;
+        }
+        return {
+            .data = cmd | ix << 8 | sub << 24 | (uint64_t)data << 32,
+            .id = id,
+            .opts = { .rtr = 0, .ide = 0, .dlc = 8},
+        };
+    }
+    static SDO fromCanMsg(Message msg) {
+        return {
+            .data = (uint32_t)(msg.data >> 32),
+            .ix = (uint16_t)(msg.data >> 8),
+            .sub = (uint8_t)(msg.data >> 24),
+            .cmd = (uint8_t)msg.data,
+            .nodeID = (uint8_t)(msg.id % 0x80),
+        };
+    }
+};
+/** CANOpen Receive Process Data Object Type */
+struct RPDO {
+    uint8_t N;
+    enum : uint8_t {SYNC, CHANGE=255} type;
+    uint32_t COB {};
+    struct MAP {
+        uint16_t ix;
+        uint8_t sub;
+        uint8_t len;
+    };
+    Buffer<MAP> map;
+    Message write(uint64_t data) const {
+        return {.data=data, .id = COB, .opts = {.dlc=8}};
+    }
+};
+/** CANOpen Transmit Process Data Object Type */
+struct TPDO {
+    uint32_t COB;
+    static TPDO fromCanMsg(Message msg) {
+        return {.COB = msg.id};
+    }
+};
+
+/** CANOpen dispatch class
+ *
+ * use this as a middle layer between the CAN bus and the Device devices to
+ * handle translation between the protocols.
+ * call this class' `process` directly after the CAN irqHandler
+ *
+ * cf. https://www.microcontrol.net/wp-content/uploads/2021/10/td-03011e.pdf
+ */
+struct Dispatch : Sink<SDO>, Sink<Message> {
+    Dispatch(CAN &can) : can(can) { }
+    CAN &can;
+#if defined(DEBUG)
+    Logger log;
+#endif
+    Sink<SDO> *ids[128] {};
+    struct PDO {
+        Sink<TPDO> *dev[8] {};
+        uint16_t cobs[8] {};
+        uint8_t n {};
+    } pdo;
+
+    using Sink<SDO>::push;
+    void push(SDO &&rq) override {
+        assert(ids[rq.nodeID] != nullptr); //must register first!
+        can.push(rq.toCanMsg());
+    }
+    using Sink<Message>::push;
+    void push(Message &&rq) override { can.push(rq); }
+
+    void registersdo(uint16_t nodeID, Sink<SDO> *dev) {
+        assert(nodeID != 0);
+        assert(ids[nodeID] == nullptr);
+        ids[nodeID] = dev;
+    }
+    void registerpdo(uint16_t COB, Sink<TPDO> *dev) {
+        assert ( pdo.n < 8 );
+        pdo.dev[pdo.n] = dev;
+        pdo.cobs[pdo.n] = COB;
+        pdo.n += 1;
+    }
+
+    Sink<TPDO> *isPDO(uint32_t cob) {
+        for (int i = 0; i < pdo.n; ++i) {
+            if (pdo.cobs[i] == cob) return pdo.dev[i];
+        }
+        return nullptr;
+    }
+    Sink<SDO> *isSDO(uint32_t cob) {
+        uint16_t service = cob & ~0x7f;
+        uint8_t id = cob & 0x7f;
+        if (id == 0) return nullptr;
+        if (service == 0x80 ||
+            service == 0x580 ||
+            service == 0x600 ||
+            service == 0x700) {
+            return ids[id];
+        }
+        return nullptr;
+    }
+
+    void process() {
+        // TODO: what to do to CAN messages that _aren't_ CanOpen
+        while (!can.empty()) {
+            auto msg = can.pop();
+            auto pdo = isPDO(msg.id);
+            if (pdo != nullptr) {
+                pdo->push(TPDO::fromCanMsg(msg));
+                continue;
+            }
+            auto sdo = isSDO(msg.id);
+            if (sdo != nullptr) {
+                sdo->push(SDO::fromCanMsg(msg));
+                continue;
+            }
+#if defined(DEBUG)
+            // don't know what to do with received message!
+            log.warn("COdispatch: [id: %d] [x%2x x%2x x%2x x%2x x%2x x%2x x%2x x%2x]\n",
+                    msg.id,
+                    (uint8_t)(msg.data),
+                    (uint8_t)(msg.data>>8),
+                    (uint8_t)(msg.data>>16),
+                    (uint8_t)(msg.data>>24),
+                    (uint8_t)(msg.data>>32),
+                    (uint8_t)(msg.data>>40),
+                    (uint8_t)(msg.data>>48),
+                    (uint8_t)(msg.data>>56)
+                    );
+#endif
+        }
+    }
+};
+
+/** CANOpen device wrapper class
+ *
+ * inherit and implement `callback` to use this interface on a CANOpen network
+ */
+struct Device : Sink<TPDO>, Sink<SDO> {
+    Device(Dispatch &canopen, uint8_t id) : id(id), out(canopen)
+    {
+        canopen.registersdo(id, this);
+    }
+    uint8_t const id {};    ///< CANOpen node ID [1 - 127]
+    Dispatch &out;
+
+    struct State {
+        Queue<SDO> q{60};
+        bool waiting{};
+    } state;
+    /** implement the callback method to handle incoming data */
+    virtual void callback(SDO rq) = 0;
+    /** implement the callback method to handle incoming data */
+    virtual void callback(TPDO rq) = 0;
+    void process() {
+        if (state.waiting || state.q.empty()) return;
+        out.push(state.q.pop());
+        state.waiting = true;
+    }
+    /** read DO with given index and subindex of this device */
+    void read(uint16_t ix, uint8_t sub) {
+        state.q.push({.ix=ix, .sub=sub, .cmd=0x40, .nodeID=id});
+        process();
+    }
+    /** write given value to DO at given index and subindex */
+    void w8(uint16_t ix, uint8_t sub, uint8_t val) {
+        state.q.push({.data=val, .ix=ix, .sub=sub, .cmd=0x2f, .nodeID=id});
+        process();
+    }
+    /** write given value to DO at given index and subindex */
+    void w16(uint16_t ix, uint8_t sub, uint16_t val) {
+        state.q.push({.data=val, .ix=ix, .sub=sub, .cmd=0x2b, .nodeID=id});
+        process();
+    }
+    /** write given value to DO at given index and subindex */
+    void w32(uint16_t ix, uint8_t sub, uint32_t val) {
+        state.q.push({.data=val, .ix=ix, .sub=sub, .cmd=0x23, .nodeID=id});
+        process();
+    }
+    /** enable receiving PDO on device */
+    void enablepdo(RPDO &pdo) {
+        if (pdo.COB == 0) pdo.COB = id + 0x100 * (pdo.N+1);
+        disablepdo(pdo);
+        w8(0x1400+pdo.N-1, 0x2, pdo.type); // set transmission type
+        w8(0x1600+pdo.N-1, 0x0, 0); // clear number of mapped objects
+        for (size_t i = 0; i < pdo.map.len; ++i) {
+            auto &d = pdo.map[i];
+            w32(0x1600+pdo.N-1, i+1, d.ix << 16 | d.sub << 8 | d.len);
+        }
+        w8(0x1600+pdo.N-1, 0x0, pdo.map.len); // set number of mapped objects
+        w32(0x1400+pdo.N-1, 0x1, 1<<30 | pdo.COB);
+    }
+    void disablepdo(RPDO &pdo) {
+        w32(0x1400+pdo.N-1, 0x1, 1<<31); // clear
+    }
+    /** send data through given pdo */
+    void wpdo(const RPDO &rpdo, uint64_t val) {
+        out.push(rpdo.write(val));
+    }
+    /** enable sending PDO on device */
+    void enablepdo(TPDO &pdo) {
+        //TODO: enable sending on device
+        out.registerpdo(pdo.COB, this);
+    };
+    void disablepdo(TPDO &pdo) {
+    };
+    using Sink<SDO>::push;
+    void push(SDO &&sdo) override {
+        state.waiting=false;
+        callback(sdo);
+        process();
+    }
+    using Sink<TPDO>::push;
+    void push(TPDO &&pdo) override {
+        callback(pdo);
+        process();
+    }
+};
+}
+}

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -70,10 +70,10 @@ struct RPDO {
         uint64_t dat = 0;
         uint8_t shift = 0;
         for (auto &i : map) {
-            dat |= (i.data & (1 << i.len)-1) << shift;
+            dat |= (i.data & ((uint64_t)1 << i.len)-1) << shift;
             shift += i.len;
         }
-        return {.data=dat, .id = COB, .opts = {.dlc=8}};
+        return {.data=dat, .id = COB, .opts = {.dlc=(uint8_t)(shift / 8)}};
     }
 };
 /** CANOpen Transmit Process Data Object Type */
@@ -86,7 +86,7 @@ struct TPDO {
     void setData(uint64_t d) {
         uint8_t shift = 0;
         for (auto &i : map) {
-            i.data = d >> shift & (1 << i.len) - 1;
+            i.data = d >> shift & ((uint64_t)1 << i.len) - 1;
             shift += i.len;
         }
     }

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -214,18 +214,18 @@ struct Device : Sink<TPDO>, Sink<SDO> {
         process();
     }
     /** write given value to DO at given index and subindex */
-    void w8(uint16_t ix, uint8_t sub, uint8_t val) {
-        state.q.push({.data=val, .ix=ix, .sub=sub, .cmd=0x2f, .nodeID=id});
+    void w8(uint16_t ix, uint8_t sub, int8_t val) {
+        state.q.push({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x2f, .nodeID=id});
         process();
     }
     /** write given value to DO at given index and subindex */
-    void w16(uint16_t ix, uint8_t sub, uint16_t val) {
-        state.q.push({.data=val, .ix=ix, .sub=sub, .cmd=0x2b, .nodeID=id});
+    void w16(uint16_t ix, uint8_t sub, int16_t val) {
+        state.q.push({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x2b, .nodeID=id});
         process();
     }
     /** write given value to DO at given index and subindex */
-    void w32(uint16_t ix, uint8_t sub, uint32_t val) {
-        state.q.push({.data=val, .ix=ix, .sub=sub, .cmd=0x23, .nodeID=id});
+    void w32(uint16_t ix, uint8_t sub, int32_t val) {
+        state.q.push({.data=(uint32_t)val, .ix=ix, .sub=sub, .cmd=0x23, .nodeID=id});
         process();
     }
     /** enable receiving PDO on device */
@@ -245,7 +245,7 @@ struct Device : Sink<TPDO>, Sink<SDO> {
         w32(0x1400+pdo.N-1, 0x1, 1<<31); // clear
     }
     /** send data through given pdo */
-    void wpdo(const RPDO &rpdo, uint64_t val) {
+    void wpdo(const RPDO &rpdo, int64_t val) {
         out.push(rpdo.write(val));
     }
     /** enable sending PDO on device */

--- a/dev/mcDSA.h
+++ b/dev/mcDSA.h
@@ -27,8 +27,8 @@ struct mcDSA : CAN::Open::Device {
 
     mcDSA(CAN::Open::Dispatch &out, uint8_t id) : CAN::Open::Device(out, id) {
         enable(false);
-        enablepdo(speedPDO);
-        enablepdo(msrPDO);
+        enablePDO(speedPDO);
+        enablePDO(msrPDO);
         enable(true);
     }
     struct Measurements {
@@ -57,7 +57,7 @@ struct mcDSA : CAN::Open::Device {
         /* int iSpeed = (int) (6000 / M_PI / CAR_WHEEL_DIAMETER * dSpeed); // calculates from m/s to (U/100) / min */
         /* int iSpeed; */
         speedPDO.map[0].data = 6000 / M_PI * speed;
-        wpdo(speedPDO);
+        wPDO(speedPDO);
     }
     double speed() {
         return msrPDO.map[0].data;

--- a/dev/mcDSA.h
+++ b/dev/mcDSA.h
@@ -1,0 +1,98 @@
+/** @file mcDSA.h
+ *
+ * Copyright (c) 2023 IACE
+ */
+#pragma once
+
+#include <cmath>
+#include <comm/canopen.h>
+
+/**
+ * @brief Driver for the mcDSA-B60 CANOpen Motor driver
+ */
+struct mcDSA : CAN::Open::Device {
+    CAN::Open::RPDO speedPDO = {
+            .N = 1,
+            .type = CAN::Open::PDOType::CHANGE,
+            .map = {{.ix = 0x3300, .sub = 0, .len = 32}},
+            };
+    CAN::Open::TPDO msrPDO = {
+            .N = 1,
+            .type = CAN::Open::PDOType::SYNC,
+            .map = {
+                {.ix = 0x3a04, .sub = 1, .len = 32}, // speed
+                {.ix = 0x3262, .sub = 1, .len = 32}, // current [mA]
+            },
+    };
+
+    mcDSA(CAN::Open::Dispatch &out, uint8_t id) : CAN::Open::Device(out, id) {
+        enable(false);
+        enablepdo(speedPDO);
+        enablepdo(msrPDO);
+        enable(true);
+    }
+    struct Measurements {
+        double speed, speedDes, current, position;
+        uint32_t error;
+    } meas;
+
+    /** Enable or Disable the motor driver */
+    void enable(bool en=true) {
+        w8(0x3004, 0, en);
+    }
+    void disable() {
+        enable(false);
+    }
+    void clear() {
+        w8(0x3000, 0, 1); // clear errors
+    }
+
+    //TODO:
+    /** Set the motor speed in u/min.
+     * Only works if device is in Operational State
+     * Capped at +- 1m/s
+     */
+    void speed(double speed) {
+        speed = fmin(1, fmax(-1, speed));
+        /* int iSpeed = (int) (6000 / M_PI / CAR_WHEEL_DIAMETER * dSpeed); // calculates from m/s to (U/100) / min */
+        /* int iSpeed; */
+        speedPDO.map[0].data = 6000 / M_PI * speed;
+        wpdo(speedPDO);
+    }
+    double speed() {
+        return msrPDO.map[0].data;
+    }
+
+    /**
+     * Read current motor data.
+     *
+     * Includes actual speed, desired speed, motor current,
+     * motor position (angle), motor error.
+     */
+    void readData() {
+        read(0x3a04, 1);//, &this->tData.tSpeed);
+        read(0x3361, 0);//, &this->tData.tSpeedDes);
+        read(0x3262, 1);//, &this->tData.tCurrent);
+        read(0x394a, 0);//, &this->tData.tPosition);
+        read(0x3001, 0);//, &this->tData.tError);
+    }
+
+    /**
+     * Return the current motor current in mA
+     */
+    double current() {
+        return msrPDO.map[1].data;
+    }
+
+    void callback(CAN::Open::SDO rq) {
+        switch(rq.ix) {
+        case 0x3a04: assert(rq.sub == 1); meas.speed = rq.data; break;
+        case 0x3361: assert(rq.sub == 0); meas.speedDes = rq.data; break;
+        case 0x3262: assert(rq.sub == 1); meas.current = rq.data; break;
+        case 0x394a: assert(rq.sub == 0); meas.position = rq.data; break;
+        case 0x3001: assert(rq.sub == 0); meas.error = rq.data; break;
+        }
+    }
+    void callback(CAN::Open::TPDO rq) {
+    }
+};

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(tool-libs-linux INTERFACE)
 target_sources(tool-libs-linux INTERFACE host.cpp)
 target_link_libraries(tool-libs-linux INTERFACE tool-libs)
+
+add_library(tool-libs-linux-can INTERFACE)
+# target_sources(tool-libs-linux-can INTERFACE can.cpp)
+target_link_libraries(tool-libs-linux-can INTERFACE tool-libs-linux)

--- a/linux/canimpl.h
+++ b/linux/canimpl.h
@@ -1,0 +1,123 @@
+#pragma once
+#include <utils/queue.h>
+#include <comm/can.h>
+#include <linux/can.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <cstring>
+#include <cstdlib>
+#include <cerrno>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+namespace CAN {
+    struct HW : public CAN {
+        int sock{};
+        Queue<Message> rx;
+        Queue<struct can_frame> tx;
+        HW( const char *ifname ) {
+            /* open CAN_RAW socket */
+            sock = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+            /* set NONBLOCK */
+            int flags = fcntl(sock, F_GETFL, 0);
+            if (flags == -1) {
+                perror("cannot get CAN socket flags");
+                abort();
+            }
+            if (fcntl(sock, F_SETFL, flags | O_NONBLOCK) == -1) {
+                perror("cannot set O_NONBLOCK on CAN socket");
+                abort();
+            }
+            /* */
+            struct ifreq ifr = {};
+            strncpy(ifr.ifr_name, ifname, IF_NAMESIZE);
+            if (ioctl(sock, SIOCGIFINDEX, &ifr) == -1) {
+                perror("cannot find CAN interface index");
+                abort();
+            }
+            /* setup address for bind */
+            struct sockaddr_can addr {
+                .can_family = PF_CAN,
+                .can_ifindex = ifr.ifr_ifindex,
+            };
+            /* bind socket to the can0 interface */
+            if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
+                perror("cannot bind socket to CAN interface");
+                abort();
+            }
+        }
+        ~HW() {
+            close(sock);
+        }
+        void push(Message &&msg) override {
+            struct can_frame frame = frameFromMessage(std::move(msg));
+            tx.push(frame);
+            process();
+        }
+        void process() {
+            // transmit side
+            while (!tx.empty()) {
+                auto frame = tx.front();
+                int l = write(sock, &frame, sizeof(frame));
+                if (l < 0) {
+                    if (errno == EAGAIN) {
+                        break;
+                    } else {
+                        perror("writing on CAN socket error");
+                    }
+                } else if (l < sizeof(frame)) {
+                    fprintf(stderr, "write: incomplete CAN frame: %d\n", l);
+                } else { // success
+                    tx.pop();
+                }
+            }
+            // receive side
+            empty();
+        }
+        using Sink::push;
+        Message pop() override {
+            return rx.pop();
+        }
+        bool empty() override {
+            struct can_frame frame;
+            int l = read(sock, &frame, sizeof(frame));
+            if (l < 0) {
+                if (errno != EAGAIN) {
+                    perror("reading on CAN socket error");
+                }
+                return rx.empty();
+            }
+            if (l < sizeof(frame)) { /* paranoid check ... */
+                fprintf(stderr, "read: incomplete CAN frame: %d\n", l);
+                return rx.empty();
+            }
+            Message msg = messageFromFrame(frame);
+            rx.push(msg);
+            return false;
+        }
+        struct can_frame frameFromMessage(Message &&msg) {
+            struct can_frame f {};
+            f.can_id = msg.id;
+            if (msg.opts.rtr) f.can_id |= CAN_RTR_FLAG;
+            f.len = msg.opts.dlc;
+            for (int i = 0; i < f.len; ++i) {
+                f.data[i] = ((uint8_t*)&msg.data)[i];
+            }
+            return f;
+        }
+        Message messageFromFrame(struct can_frame frame) {
+            Message msg {
+                .id = frame.can_id & ((1<<30)-1),
+                .opts = {
+                    .rtr = !!(frame.can_id & CAN_RTR_FLAG),
+                    .dlc = frame.len,
+                },
+            };
+            for (int i = 0; i < frame.len; ++i) {
+                ((uint8_t*)&msg.data)[i] = frame.data[i];
+            }
+            return msg;
+        }
+    };
+}

--- a/stm/CMakeLists.txt
+++ b/stm/CMakeLists.txt
@@ -23,3 +23,9 @@ target_sources(tool-libs-stm-uart INTERFACE uart.cpp)
 target_link_libraries(tool-libs-stm-uart INTERFACE tool-libs-stm)
 target_compile_definitions(tool-libs-stm-uart INTERFACE
     HAL_UART_MODULE_ENABLED USE_HAL_UART_REGISTER_CALLBACKS=1)
+
+add_library(tool-libs-stm-can INTERFACE)
+target_sources(tool-libs-stm-can INTERFACE can.cpp)
+target_link_libraries(tool-libs-stm-can INTERFACE tool-libs-stm)
+target_compile_definitions(tool-libs-stm-can INTERFACE
+    HAL_CAN_MODULE_ENABLED USE_HAL_CAN_REGISTER_CALLBACKS=1)

--- a/stm/can.cpp
+++ b/stm/can.cpp
@@ -1,0 +1,131 @@
+#include "can.h"
+
+using namespace CAN;
+
+void _start(CAN_HandleTypeDef *handle, const Message &msg) {
+    uint32_t mbox;
+    CAN_TxHeaderTypeDef header = {
+        .StdId = msg.opts.ide ? 0 : msg.id & 0x7ff,
+        .ExtId = msg.opts.ide ? msg.id : 0,
+        .IDE = msg.opts.ide ? CAN_ID_EXT : CAN_ID_STD,
+        .RTR = msg.opts.rtr ? CAN_RTR_REMOTE : CAN_RTR_DATA,
+        .DLC = msg.opts.dlc,
+    };
+    HAL_CAN_AddTxMessage(handle, &header, (uint8_t*)&msg.data, &mbox);
+    HW::reg.from(handle)->tx.active |= mbox;
+}
+template<int N>
+void _tx_complete(CAN_HandleTypeDef *handle) {
+    auto can = HW::reg.from(handle);
+    assert(can->tx.active & 1<<N);
+    can->tx.active &= ~(1<<N);
+    while (can->tx.q.size() && HAL_CAN_GetTxMailboxesFreeLevel(handle)) {
+        _start(handle, can->tx.q.pop());
+    }
+}
+template<int N>
+void _rx_complete(CAN_HandleTypeDef *handle) {
+    CAN_RxHeaderTypeDef header{};
+    Message msg{};
+    HAL_CAN_GetRxMessage(handle, N?CAN_RX_FIFO1:CAN_RX_FIFO0, &header, (uint8_t*)&msg.data);
+    msg.id = header.IDE ? header.ExtId : header.StdId;
+    msg.opts = {
+        .rtr = (bool)header.RTR,
+        .ide = (bool)header.IDE,
+        .dlc = (uint8_t)header.DLC,
+    };
+    HW::reg.from(handle)->rx.push(std::move(msg));
+}
+
+HW::HW(const Config &c) {
+    HW::reg.reg(this, &handle);
+
+    /* Can speed configuration. */
+    /* Based on the values obtained from http://bittiming.can-wiki.info */
+    /* Assuming CAN clock is 108 MHz */
+
+    uint32_t Prescaler = 27;
+    uint32_t ts1 = CAN_BS1_13TQ;
+    uint32_t ts2 = CAN_BS2_2TQ;
+
+    switch (c.kbaud) {
+        case 1000:
+            Prescaler = 3;
+            ts1 = CAN_BS1_15TQ;
+            ts2 = CAN_BS2_2TQ;
+            break;
+        case 500:
+            Prescaler = 6;
+            ts1 = CAN_BS1_15TQ;
+            ts2 = CAN_BS2_2TQ;
+            break;
+        case 250:
+            Prescaler = 12;
+            ts1 = CAN_BS1_15TQ;
+            ts2 = CAN_BS2_2TQ;
+            break;
+        case 125:
+            Prescaler = 27;
+            ts1 = CAN_BS1_13TQ;
+            ts2 = CAN_BS2_2TQ;
+            break;
+        default :
+            assert(false); // don't know that baud
+    }
+    /* Configure CAN module registers */
+    /* Configuration is handled by CubeMX HAL*/
+    handle = {
+        .Instance = c.can,
+        .Init = {
+            .Prescaler = Prescaler,
+			.Mode = CAN_MODE_NORMAL,
+			.SyncJumpWidth = CAN_SJW_1TQ,
+            .TimeSeg1 = ts1,
+            .TimeSeg2 = ts2,
+			.TimeTriggeredMode = DISABLE,
+			.AutoBusOff = DISABLE,
+			.AutoWakeUp = DISABLE,
+			.AutoRetransmission = ENABLE,
+			.ReceiveFifoLocked = DISABLE,
+			.TransmitFifoPriority = DISABLE,
+        },
+    };
+
+    /* CLEAR_BIT(c.can->MCR, 1 << 16); // freeze CAN during debug */
+    while (HAL_CAN_Init(&handle) != HAL_OK);
+
+    /* accept _all_ received messages i.e. activate empty filters */
+    CAN_FilterTypeDef FilterConfig = {
+        .FilterActivation = true,
+    };
+    while (HAL_CAN_ConfigFilter(&handle, &FilterConfig) != HAL_OK) ;
+
+
+    HAL_CAN_RegisterCallback(&handle, HAL_CAN_TX_MAILBOX0_COMPLETE_CB_ID, _tx_complete<0>);
+    HAL_CAN_RegisterCallback(&handle, HAL_CAN_TX_MAILBOX1_COMPLETE_CB_ID, _tx_complete<1>);
+    HAL_CAN_RegisterCallback(&handle, HAL_CAN_TX_MAILBOX2_COMPLETE_CB_ID, _tx_complete<2>);
+    HAL_CAN_RegisterCallback(&handle, HAL_CAN_RX_FIFO0_MSG_PENDING_CB_ID, _rx_complete<0>);
+    HAL_CAN_RegisterCallback(&handle, HAL_CAN_RX_FIFO1_MSG_PENDING_CB_ID, _rx_complete<1>);
+
+    while (HAL_CAN_ActivateNotification(&handle,
+                                     CAN_IT_RX_FIFO0_MSG_PENDING |
+                                     CAN_IT_RX_FIFO1_MSG_PENDING |
+                                     CAN_IT_TX_MAILBOX_EMPTY)) ;
+
+    while (HAL_CAN_Start(&handle) != HAL_OK) ;
+}
+
+HW::~HW() {
+    HAL_CAN_DeactivateNotification(&handle,
+                                   CAN_IT_RX_FIFO0_MSG_PENDING |
+                                   CAN_IT_RX_FIFO1_MSG_PENDING |
+                                   CAN_IT_TX_MAILBOX_EMPTY);
+    HAL_CAN_Stop(&handle);
+}
+void HW::push(Message &&msg) {
+    if (HAL_CAN_GetTxMailboxesFreeLevel(&handle)) {
+        _start(&handle, std::move(msg));
+    } else {
+        tx.q.push(std::move(msg));
+    }
+}

--- a/stm/can.h
+++ b/stm/can.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <utils/queue.h>
+#include <comm/can.h>
+
+#include "gpio.h"
+#include "registry.h"
+
+namespace CAN {
+/** CAN peripheral driver */
+struct HW : public CAN {
+    inline static Registry<HW, CAN_HandleTypeDef, 2> reg;
+    struct Config {
+        CAN_TypeDef *can; ///< CAN peripheral
+        AFIO rx, tx; ///< alternate function initialized pins
+        uint32_t kbaud; ///< baudrate
+    };
+    HW(const Config &);
+    ~HW();
+    void push(Message &&) override;
+    using Sink::push;
+    Message pop() override { return rx.pop(); };
+    bool empty() override { return rx.empty(); };
+
+    Queue<Message> rx;
+
+    struct TX {
+        Queue<Message> q;
+        uint8_t active;
+    } tx{};
+
+    void irqHandler() { HAL_CAN_IRQHandler(&handle); };
+    CAN_HandleTypeDef handle{};
+};
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,8 +8,8 @@ FetchContent_Declare( doctest
 )
 FetchContent_MakeAvailable(doctest)
 
-function(make_test name)
-	add_executable(test-${name} main.cpp ${name}.cpp)
+function(make_test_standalone name)
+	add_executable(test-${name} ${name}.cpp)
 	target_compile_features(test-${name} PRIVATE cxx_std_17)
 	target_include_directories(test-${name} PUBLIC ${DOCTEST_INCLUDE_DIR})
 	target_link_libraries(test-${name} PUBLIC tool-libs doctest::doctest ${ARGN})
@@ -20,6 +20,11 @@ function(make_test name)
 		COMMAND ./test-${name}
 		VERBATIM
 	)
+endfunction()
+
+function(make_test name)
+	make_test_standalone(${name} ${ARGN})
+	target_sources(test-${name} PRIVATE main.cpp)
 	set(TOOL-LIBS-TESTS "test-${name}-run;${TOOL-LIBS-TESTS}" PARENT_SCOPE)
 endfunction()
 
@@ -33,6 +38,8 @@ make_test(min)
 make_test(movingaverage)
 make_test(Queue)
 make_test(TFR)
+
+make_test_standalone(canlinux tool-libs-linux-can)
 
 add_custom_target(test-run
 	DEPENDS ${TOOL-LIBS-TESTS}

--- a/tests/canlinux.cpp
+++ b/tests/canlinux.cpp
@@ -1,0 +1,27 @@
+#include <core/kern.h>
+#include <comm/canopen.h>
+#include <linux/canimpl.h>
+
+Kernel k;
+using namespace CAN;
+HW can ("can0");
+Open::Dispatch canopen(can);
+
+struct DEV : public Open::Device {
+    DEV() : Device(canopen, 0x0F) { }
+    void callback(Open::SDO rq) override { }
+    void callback(Open::TPDO rq) override { }
+} dev{};
+
+
+int main() {
+    k.every(1, [](uint32_t t, uint32_t dt) {
+            canopen.process();
+            });
+    k.every(2000, [](uint32_t t, uint32_t dt) {
+            dev.w32(0x3005, 0x1, t);
+            });
+    k.run();
+    return 0;
+};
+


### PR DESCRIPTION
this is a work in progress, focuses on `stm` backend for now, should be fairly easy to implement the interface found in `comm/can.h` for the linux backend as well, the `CAN::Open::Dispatch` (name up for discussion) layer should stay the same

- [ ] mcDSA umrechnungsfaktoren