### PR TITLE
Constructors

### DIFF
--- a/ctrl/trajectory.h
+++ b/ctrl/trajectory.h
@@ -23,12 +23,8 @@ public:
     /** virtual destructor */
     virtual ~Curve() {}
 
-    Curve() : diffs(2) {
-        for (int i = 0; i < diffs.size; ++i) diffs.append(0);
-    }
-
-    Curve(size_t n) : diffs(n) {
-        for (int i = 0; i < diffs.size; ++i) diffs.append(0);
+    Curve(size_t n=2) : diffs(n) {
+        for (size_t i = 0; i < diffs.size; ++i) diffs.append(0);
     }
 
     Buffer<double> operator()(double dx) {
@@ -48,9 +44,7 @@ class LinearTrajectory : public Curve {
     };
     Buffer<Vec> P;
 public:
-    LinearTrajectory() : Curve(2) {}
-
-    LinearTrajectory(size_t diffs) : Curve(diffs) {}
+    LinearTrajectory(size_t diffs=2) : Curve(diffs) {}
 
     void setData(Buffer<double> &&b) override {
         size_t off{b.size / 2};
@@ -108,7 +102,7 @@ class SmoothTrajectory : public Curve {
     };
     Buffer<Vec> P;
 public:
-    SmoothTrajectory(Buffer<double> coeffs, size_t n) : coeffs{coeffs}, n(n), Curve(coeffs.len) {}
+    SmoothTrajectory(Buffer<double> coeffs, size_t n) : Curve(coeffs.len), n(n), coeffs(coeffs) {}
 
     void setData(Buffer<double> &&b) override {
         size_t off{b.size / 2};

--- a/ctrl/trajectory.h
+++ b/ctrl/trajectory.h
@@ -188,4 +188,19 @@ struct Reference {
         }
         return *this;
     }
+    Reference() { }
+    Reference(std::initializer_list<double> list) {
+        assert(list.size() == n);
+        int i = 0;
+        for (auto l = list.begin(); l != list.end(); ++l, ++i) {
+            y[i] = *l;
+        }
+    }
+    Reference(const Buffer<double> &b) {
+        assert(b.len == n);
+        int i = 0;
+        for (auto l = b.begin(); l != b.end(); ++l, ++i) {
+            y[i] = *l;
+        }
+    }
 };


### PR DESCRIPTION
this simplifies some assignments.

i.e. from `furuta`

```cpp
Reference<3> des;
Buffer<double> Tdes;
//switch case 
{
Tdes = std::get<LinearTrajectory>(traj).getValue(t);
}
for (int i = 0; i < des.size(); ++i) {
        des[i] = Tdes[i];
}
```

can now just be
```cpp
Reference<3> des;
des = std::get<LinearTrajectory>(traj).getValue(t);
```