### PR TITLE
testing improvements + fix queue getAt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,21 @@
 cmake_minimum_required(VERSION 3.25)
 cmake_policy(VERSION 3.25)
 
+project(tool-libs
+	HOMEPAGE_URL https://github.com/umit-iace/tool-libs
+	LANGUAGES C CXX ASM
+)
+
+option(TEST "generate test targets" FALSE)
+
 add_library(tool-libs INTERFACE)
 target_include_directories(tool-libs INTERFACE .)
 
 add_subdirectory(stm)
 add_subdirectory(linux)
-add_subdirectory(tests)
+if (PROJECT_IS_TOP_LEVEL OR TEST)
+    add_subdirectory(tests)
+endif()
 
 find_package(Doxygen)
 if(DOXYGEN_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-project(libs_tests VERSION 0.0.1 LANGUAGES CXX)
-
 include(FetchContent)
 set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare( doctest
@@ -10,31 +8,32 @@ FetchContent_Declare( doctest
 )
 FetchContent_MakeAvailable(doctest)
 
-# Make test executable
-add_executable(tool-libs-tests main.cpp
-    buffer.cpp
-    experiment.cpp
-    frameregistry.cpp
-    interpolation.cpp
-    later.cpp
-    min.cpp
-    movingaverage.cpp
-    Queue.cpp
-    TFR.cpp
-    )
-target_compile_features(tool-libs-tests PRIVATE cxx_std_17)
-target_include_directories(tool-libs-tests PUBLIC ${DOCTEST_INCLUDE_DIR})
-target_link_libraries(tool-libs-tests PUBLIC tool-libs doctest::doctest)
+function(make_test name)
+	add_executable(test-${name} main.cpp ${name}.cpp)
+	target_compile_features(test-${name} PRIVATE cxx_std_17)
+	target_include_directories(test-${name} PUBLIC ${DOCTEST_INCLUDE_DIR})
+	target_link_libraries(test-${name} PUBLIC tool-libs doctest::doctest ${ARGN})
 
-add_custom_target(tool-libs-tests-run
-    DEPENDS tool-libs-tests
-    COMMAND valgrind -s --leak-check=full "${CMAKE_CURRENT_BINARY_DIR}/tool-libs-tests"
-    )
+	add_custom_target(test-${name}-run
+		DEPENDS test-${name}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		COMMAND ./test-${name}
+		VERBATIM
+	)
+	set(TOOL-LIBS-TESTS "test-${name}-run;${TOOL-LIBS-TESTS}" PARENT_SCOPE)
+endfunction()
 
-add_executable(bitstream bitstream.cpp)
-target_link_libraries(bitstream PUBLIC tool-libs doctest::doctest)
-add_custom_target(bitstream-test
-    DEPENDS bitstream
-    COMMAND ./bitstream
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+make_test(bitstream)
+make_test(buffer)
+make_test(experiment)
+make_test(frameregistry)
+# make_test(interpolation)
+make_test(later)
+make_test(min)
+make_test(movingaverage)
+make_test(Queue)
+make_test(TFR)
+
+add_custom_target(test-run
+	DEPENDS ${TOOL-LIBS-TESTS}
 )

--- a/tests/Queue.cpp
+++ b/tests/Queue.cpp
@@ -81,3 +81,18 @@ TEST_CASE("tool-libs: queue: roundabout") {
         }
     }
 }
+TEST_CASE("tool-libs: queue: indexed access") {
+    Queue<int> q{10};
+    for (int i = 0; i < 7; ++i) {
+        q.push(i);
+        CHECK(i == q.getAt(0));
+        q.pop();
+    }
+    CHECK(q.size() == 0);
+    for (int i = 0; i < 5; ++i) {
+        q.push(i);
+    }
+    for (int i = 0; i < 5; ++i) {
+        CHECK(i == q.getAt(i));
+    }
+}

--- a/tests/bitstream.cpp
+++ b/tests/bitstream.cpp
@@ -1,8 +1,7 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 #include <iostream>
 
-#include "utils/bitstream.h"
+#include <utils/bitstream.h>
 struct Data {
     uint8_t cnf:6;
     int16_t pos:12;

--- a/utils/bitstream.h
+++ b/utils/bitstream.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 IACE
  */
 #pragma once
-#include <stdio.h>
+#include <stdint.h>
 
 /**
  * Wrapper for extracting bitwise data from a stream of bytes.

--- a/utils/queue.h
+++ b/utils/queue.h
@@ -77,6 +77,6 @@ public:
     }
     /** return element at idx */
     T getAt(size_t idx) {
-        return q[(tail + idx) % q.size];
+        return q[(head + idx) % q.size];
     }
 };


### PR DESCRIPTION
https://github.com/umit-iace/tool-libs/blob/434b4cf7294f2aa0dea47e3b3bcc53fffd6aca5d/utils/queue.h#L80

the implementation of this function only does the Right Thing<sup>TM</sup> if the queue is actually full. i know this is currently only used in HeliRack and only ever with the queue actually being full, but getting it correct now will stop surprises in the future.

i think the semantics of this function should be 'get the `n`th item in the queue' -- no matter how many items are actually in the queue.

this series of commits first improves the testing situation of the tool-libs, then adds a test-case for how i understand  `getAt`  should work, and finally fixes the implementation to actually work that way.

one could still discuss the usefullness of asserting `idx < q.len` in the `getAt` function, as using an index greater than that would access either uninitialized or old memory.