### PR TITLE
Queuedrop

### DIFF
--- a/stm/can.cpp
+++ b/stm/can.cpp
@@ -20,7 +20,8 @@ void _tx_complete(CAN_HandleTypeDef *handle) {
     assert(can->tx.active & 1<<N);
     can->tx.active &= ~(1<<N);
     while (can->tx.q.size() && HAL_CAN_GetTxMailboxesFreeLevel(handle)) {
-        _start(handle, can->tx.q.pop());
+        _start(handle, can->tx.q.front());
+        can->tx.q.drop();
     }
 }
 template<int N>

--- a/stm/i2c.cpp
+++ b/stm/i2c.cpp
@@ -91,7 +91,8 @@ void _complete(I2C_HandleTypeDef *handle) {
     auto i2c = HW::reg.from(handle);
     switch (i2c->active) {
     case i2c->Q:
-        i2c->q.front().dev->callback(i2c->q.pop());
+        i2c->q.front().dev->callback(i2c->q.front());
+        i2c->q.drop();
         break;
     case i2c->IN:
         i2c->in.dev->callback(std::move(i2c->in));

--- a/stm/spi.cpp
+++ b/stm/spi.cpp
@@ -89,7 +89,7 @@ void _complete(SPI_HandleTypeDef *handle) {
     auto& rq = spi->q.front();
     rq.dev->select(false);
     rq.dev->callback(rq);
-    spi->q.pop();
+    spi->q.drop();
     spi->deadline = {};
     spi->active.xfer = false;
     poll(spi);

--- a/stm/sys/i2c.h
+++ b/stm/sys/i2c.h
@@ -27,7 +27,7 @@ struct Device {
     /**
      * callback. is called as soon as transmission completed successfully
      */
-    virtual void callback(const Request req)=0;
+    virtual void callback(const Request &req)=0;
 };
 
 /**

--- a/stm/uart.cpp
+++ b/stm/uart.cpp
@@ -148,7 +148,7 @@ void _rxcallback(UART_HandleTypeDef *handle) {
 void _txcallback(UART_HandleTypeDef *handle) {
     auto uart = HW::reg.from(handle);
     auto& tx = uart->tx;
-    tx.q.pop();
+    tx.q.drop();
     tx.active = false;
     tx.deadline = Deadline{};
     poll(uart);

--- a/utils/queue.h
+++ b/utils/queue.h
@@ -63,6 +63,14 @@ public:
         q.len--;
         return std::move(q[head++]);
     }
+    /**
+     * shift head of queue without touching underlying memory
+     */
+    void drop() {
+        assert(q.len != 0);
+        q.len--;
+        head++;
+    }
     /** return number of elements in queue */
     size_t size() {
         return q.len;


### PR DESCRIPTION
second attempt.

if this works well for the `I2C` peripheral, the last commit also adapts all the other interrupts where we currently use `pop()`.
