### PR TITLE
core: portably fix time printing

### DIFF
--- a/core/experiment.h
+++ b/core/experiment.h
@@ -36,7 +36,7 @@ extern class Experiment {
         virtual Buffer<uint8_t> pre() override {
             Buffer<uint8_t> ret = 256;
             ret.len = snprintf((char*)ret.buf, ret.size,
-                    "Experiment Logger (@%w32dms): ", time);
+                    "Experiment Logger (@%" PRIu32 "ms): ", time);
             return ret;
         }
         ELog(const uint32_t &time, Sink<Buffer<uint8_t>> &underlying)

--- a/core/kern.h
+++ b/core/kern.h
@@ -6,6 +6,7 @@
 #include "timed.h"
 #include "logger.h"
 #include <setjmp.h>
+#include <inttypes.h>
 
 /** simple kernel for running tool-libs based applications
  *
@@ -20,7 +21,7 @@ extern class Kernel :
         const uint32_t &time;
         virtual Buffer<uint8_t> pre() override {
             Buffer<uint8_t> ret = 256;
-            ret.len = snprintf((char*)ret.buf, ret.size, "(@%w32dms): ", time);
+            ret.len = snprintf((char*)ret.buf, ret.size, "(@%" PRIu32 "ms): ", time);
             return ret;
         }
     };


### PR DESCRIPTION
implements #113 for now. revert as soon as compilers understand specific width length modifiers