### PR TITLE
Sink: add 'full' and 'trypush' methods

### DIFF
--- a/comm/bufferutils.h
+++ b/comm/bufferutils.h
@@ -23,6 +23,9 @@
  */
 struct SplitPush : Sink<Buffer<uint8_t>> {
     Sink<Buffer<uint8_t>> &left, &right;
+    bool full() override {
+        return left.full() || right.full();
+    }
     void push(Buffer<uint8_t> &&in) override {
         left.push(in);
         right.push(in);
@@ -67,6 +70,9 @@ struct SplitPull {
         }
         Buffer<uint8_t> pop() override {
             return q.pop();
+        }
+        bool full() override {
+            return q.full();
         }
         void push(Buffer<uint8_t> &&t) override {
             q.push(std::move(t));
@@ -132,6 +138,9 @@ struct Hexify : Sink<Buffer<uint8_t>> {
     static constexpr size_t blen = 512*3;
     Sink<Buffer<uint8_t>> &down;
     Buffer<uint8_t> work = blen;
+    bool full() override {
+        return down.full();
+    }
     void push(Buffer<uint8_t> &&in) override {
         for (auto b: in) {
             work.append({'\\', map[b >> 4], map[b & 0xf]});

--- a/comm/bufferutils.h
+++ b/comm/bufferutils.h
@@ -116,7 +116,7 @@ struct Tee : Source<Buffer<uint8_t>> {
         while (!q.full() && !from.empty()) {
             auto b = from.pop();
             q.push(b);
-            to.push(std::move(b));
+            to.trypush(std::move(b));
         }
         return q.empty();
     }

--- a/comm/canopen.h
+++ b/comm/canopen.h
@@ -155,6 +155,9 @@ struct Dispatch : Sink<SDO>, Sink<Message> {
         }
     }
 
+    bool full() override {
+        return can.full();
+    }
     using Sink<SDO>::push;
     void push(SDO &&rq) override {
         //assert(ids[rq.nodeID] != nullptr); //must register first!
@@ -301,6 +304,9 @@ struct Device : Sink<TPDO>, Sink<SDO> {
     void disablePDO(TPDO &pdo) {
         w32(0x1800+pdo.N-1, 0x1, 1<<31); // clear
     };
+    bool full() override {
+        return (*(Sink<Message>*)&out).full();
+    }
     using Sink<SDO>::push;
     void push(SDO &&sdo) override {
         state.next = {0};

--- a/comm/line.h
+++ b/comm/line.h
@@ -54,6 +54,9 @@ class LineDelimiter : public Sink<Buffer<uint8_t>> {
 public:
     /** set underlying Sink */
     LineDelimiter(Sink<Buffer<uint8_t>> &p): p(p) { }
+    bool full() override {
+        return p.full();
+    }
     void push(const Buffer<uint8_t> &b) override {
         if (b.len + 1 <= b.size) {
             push(std::move(Buffer<uint8_t>{b}));

--- a/comm/line.h
+++ b/comm/line.h
@@ -19,11 +19,7 @@ class LineFilter : public Source<Buffer<uint8_t>> {
         // handle both \n and \r\n newlines
         if (b == '\n' || b == '\r') {
             if (l.len == 0) return;
-            if (!q.full()) {
-                q.push(std::move(l));
-            } else {
-                // fallthrough: Drop Line, queue was full
-            }
+            q.trypush(std::move(l));
             l = linelen;
             return;
         }

--- a/comm/min.h
+++ b/comm/min.h
@@ -151,7 +151,7 @@ struct Min {
                     frame_crc |= b;
                     if (frame_crc == crc.finalize()) {
                         // Frame received OK, pass up data to handler
-                        queue.push(std::move(frame));
+                        queue.trypush(std::move(frame));
                         frame = {};
                     }
                     // Either the frame failed, or we already handled it
@@ -252,7 +252,7 @@ struct Min {
             stuff((uint8_t) ((sum >> 8) & 0xff));
             stuff((uint8_t) ((sum >> 0) & 0xff));
             nostuff(EOF_BYTE);
-            out.push(std::move(req));
+            out.trypush(std::move(req));
         }
         void *operator new(size_t sz, Out *where) {
             return where;

--- a/comm/min.h
+++ b/comm/min.h
@@ -39,7 +39,7 @@ struct Min {
         EOF_BYTE = 0x55U,
     };
     /** incoming Min stream
-     * 
+     *
      * check data availability from underlying Buffer stream with
      * `empty()` then `pop()` and use data
      * ```
@@ -191,7 +191,7 @@ struct Min {
         }
     };
     /** outgoing Min stream
-     * 
+     *
      * pushes data out directly to underlying Buffer stream
      *
      * \dot
@@ -231,6 +231,9 @@ struct Min {
         /** create Buffer stream wrapper */
         Out(Sink<Buffer<uint8_t>> &to) : out{to} { }
         using Sink<Frame>::push;
+        bool full() override {
+            return out.full();
+        }
         /** push Frame through to underlying Buffer stream */
         void push(Frame &&f) override {
             req = 128;

--- a/core/experiment.h
+++ b/core/experiment.h
@@ -104,7 +104,8 @@ public:
                 Sink<Frame> &s;
                 TMP(Sink<Frame>&s): s(s) {}
                 void call() override{
-                    s.push(Frame{1}.pack(false));
+                    auto f = Frame{1}.pack(false);
+                    s.trypush(std::move(f));
                 }};
         timeout.call(new TMP{notify});
     }

--- a/core/kern.h
+++ b/core/kern.h
@@ -34,7 +34,8 @@ public:
     }
     /** call every ms */
     void tick(uint32_t dt_ms) {
-        schedule(time, *this);
+        auto ok = schedule(time, *this);
+        if (!ok) exit( 127 ); // too many items in scheduled queue. DYING.
         time_ += dt_ms;
     }
     /** kernel entry point */

--- a/core/logger.h
+++ b/core/logger.h
@@ -10,8 +10,8 @@ template<typename T>
 struct DevNull: Sink<T>, Source<T> {
     bool empty() override { return true; }
     T pop() override { return T{}; }
-    void push(T &&) override {
-    }
+    bool full() override { return false; }
+    void push(T &&) override { }
 };
 /** black-hole sink & source, just drops all data, provides none */
 template<typename T>
@@ -59,8 +59,11 @@ public:
         mklog(NONE, fmt, args);
         va_end(args);
     }
+    bool full() override {
+        return out.full();
+    }
     /** push otherwisely prepared Buffer through Logger */
-    void push(Buffer<uint8_t> &&b) {
+    void push(Buffer<uint8_t> &&b) override {
         Buffer<uint8_t> tmp = pre();
         for (auto &c : b) { tmp.append(c); }
         out.push(std::move(tmp));

--- a/core/logger.h
+++ b/core/logger.h
@@ -35,7 +35,7 @@ struct Logger : Sink<Buffer<uint8_t>> {
         if (lvl != NONE) {
             b.len += snprintf((char*)b.buf+b.len, b.size-b.len, "%s", color[NONE]);
         }
-        out.push(std::move(b));
+        out.trypush(std::move(b));
     }
 public:
     /** Info log level */

--- a/core/schedule.h
+++ b/core/schedule.h
@@ -49,10 +49,12 @@ struct Scheduler {
     // we do not own them
     Queue<Schedule::Schedulable*> q;
     /** schedule all registered schedulables of registry if necessary */
-    void schedule(uint32_t time, Schedule::Registry &reg) {
+    bool schedule(uint32_t time, Schedule::Registry &reg) {
         for (auto &c: reg.list) {
+            if (q.full()) return false;
             if (c->schedule(time)) q.push(c);
         }
+        return true;
     }
     /** run scheduled calls */
     void run() {

--- a/core/streams.h
+++ b/core/streams.h
@@ -13,12 +13,22 @@
  */
 template<typename T>
 struct Sink {
+    /// check if sink is full
+    virtual bool full()=0;
     /// copy semantics
+    /// does _not_ check for space. guard by using 'if (!full) { ... }'
     virtual void push(const T& t) {
         push(std::move(T{t}));
     }
     /// move semantics
+    /// does _not_ check for space. guard by using 'if (!full) { ... }'
     virtual void push(T&&)=0;
+    /// use this if you don't care if it's going to be successful.
+    /// data gets discarded if sink is full.
+    void trypush(T&& t) {
+        if (full()) return;
+        push(std::move(t));
+    }
 };
 
 /** generic object source, i.e. generator of objects
@@ -31,5 +41,6 @@ struct Source {
     /// check if source is empty
     virtual bool empty()=0;
     /// pull object from source
+    /// does _not_ check for data. guard by using 'if (!empty) { ... }'
     virtual T pop()=0;
 };

--- a/dev/ADS1115.h
+++ b/dev/ADS1115.h
@@ -145,14 +145,14 @@ private:
     }
     double adc{0};
     void setPointer(uint8_t reg) {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = {reg},
         });
     }
 
     void read() {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = 2,
             .opts = {
@@ -162,7 +162,7 @@ private:
     }
 
     void write(uint8_t reg, uint16_t val) {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = {reg, (uint8_t)(val>>8), (uint8_t)val},
             });

--- a/dev/AS5048b.h
+++ b/dev/AS5048b.h
@@ -25,7 +25,7 @@ public:
      * start async read of angle
      */
     void measure() {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = 2,
             .opts = {

--- a/dev/AS5145.h
+++ b/dev/AS5145.h
@@ -46,7 +46,7 @@ struct AS5145 : SPI::Device {
      * request measurement of sensor data
      */
     void sense() {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = BYTES,
             .dir = SPI::Request::MISO,

--- a/dev/BMI160.h
+++ b/dev/BMI160.h
@@ -21,7 +21,7 @@ struct BMI160 : I2C::Device {
             : I2C::Device(bus, addr) {
         writeReg(0x7e, 0x11);   // enable accelerometer
         writeReg(0x7e, 0x15);   // enable gyroscope
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = {0xc}, // set read pointer to gyro data
             });
@@ -31,7 +31,7 @@ struct BMI160 : I2C::Device {
      * start async read-out of sensor data
      */
     void measure() {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = 12,
             .opts = {
@@ -45,7 +45,7 @@ struct BMI160 : I2C::Device {
     double factor_a{9.81 / 16384}, factor_g{3.14 / 180 / 16.4};
 
     void writeReg(uint8_t reg, uint8_t val) {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = {val},
             .opts = {

--- a/dev/HMC5883L.h
+++ b/dev/HMC5883L.h
@@ -70,7 +70,7 @@ struct HMC5883L : I2C::Device {
      * start async read of angle
      */
     void measure() {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = 6,
             .opts = {
@@ -82,7 +82,7 @@ struct HMC5883L : I2C::Device {
     }
 
     void writeReg(uint8_t reg, uint8_t val) {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = {val},
             .opts = {

--- a/dev/MAX31855.h
+++ b/dev/MAX31855.h
@@ -43,7 +43,7 @@ struct MAX31855 : SPI::Device {
      * request measurement of sensor data
      */
     void sense() {
-        bus.push({
+        bus.trypush({
             .dev = this,
             .data = 4,
             .dir = SPI::Request::MISO,

--- a/dev/MAX31865.h
+++ b/dev/MAX31865.h
@@ -169,7 +169,7 @@ struct MAX31865 : SPI::Device {
      * @param thr threshold
      */
     void setLThr(uint16_t thr) {
-        bus.push({
+        bus.trypush({
                 .dev = this,
                 .data = {WRITE | REG_LOW_FAULT_THRESHOLD, (uint8_t)(thr>>8), (uint8_t)thr},
                 .dir = SPI::Request::MOSI,
@@ -181,7 +181,7 @@ struct MAX31865 : SPI::Device {
      * @param thr threshold
      */
     void setHThr(uint16_t thr) {
-        bus.push({
+        bus.trypush({
                 .dev = this,
                 .data = {WRITE | REG_HIGH_FAULT_THRESHOLD, (uint8_t)(thr>>8), (uint8_t)thr},
                 .dir = SPI::Request::MOSI,
@@ -213,7 +213,7 @@ private:
 
     void setConfig(uint8_t val) {
         data.config = val;
-        bus.push({
+        bus.trypush({
                 .dev = this,
                 .data = {WRITE|REG_CONFIG, data.config},
                 .dir = SPI::Request::MOSI,
@@ -221,7 +221,7 @@ private:
     }
 
     void getTempData() {
-        bus.push({
+        bus.trypush({
                 .dev = this,
                 .data = {READ|REG_RTD, 0, 0},
                 .dir = SPI::Request::BOTH,
@@ -229,7 +229,7 @@ private:
     }
 
     void getStatusData() {
-        bus.push({
+        bus.trypush({
                 .dev = this,
                 .data = {READ|REG_STATUS, 0},
                 .dir = SPI::Request::BOTH,
@@ -237,7 +237,7 @@ private:
     }
 
     void getAllData() {
-        bus.push({
+        bus.trypush({
                 .dev = this,
                 .data = {READ|REG_CONFIG, 0,0,0,0,0,0,0,0},
                 .dir = SPI::Request::BOTH,

--- a/dev/ODrive.h
+++ b/dev/ODrive.h
@@ -60,7 +60,7 @@ struct ODrive {
             }
             Buffer<uint8_t> cmd = 32;
             cmd.len = snprintf((char*)cmd.buf, cmd.size, cmds.velocity, side, speed, 0);
-            drive->q.push({
+            drive->q.trypush({
                     .cmd = VELO,
                     .m = this,
                     .out = std::move(cmd),
@@ -75,7 +75,7 @@ struct ODrive {
             }
             Buffer<uint8_t> cmd = 32;
             cmd.len = snprintf((char*)cmd.buf, cmd.size, cmds.get, side);
-            drive->q.push({
+            drive->q.trypush({
                     .cmd = GET,
                     .m = this,
                     .out = std::move(cmd),
@@ -101,7 +101,7 @@ struct ODrive {
                     _alive = true;
                 }
             } else if (k.time % 500 == 0) {
-                out.push({(const uint8_t*)"r vbus_voltage\n", 16});
+                out.trypush({(const uint8_t*)"r vbus_voltage\n", 16});
             }
             return;
         }
@@ -112,7 +112,7 @@ struct ODrive {
             req.m->callback(req, resp);
         }
         while (!q.empty() && q.front().out.buf) { // command has not been sent
-            out.push(std::move(q.front().out));
+            out.trypush(std::move(q.front().out));
             if (q.front().cmd != GET) { // only expect response from GET
                 q.pop();
             }

--- a/linux/sys/can.h
+++ b/linux/sys/can.h
@@ -50,6 +50,9 @@ namespace CAN {
         ~HW() {
             close(sock);
         }
+        bool full() override {
+            return tx.full();
+        }
         void push(Message &&msg) override {
             struct can_frame frame = frameFromMessage(std::move(msg));
             tx.push(frame);

--- a/linux/sys/comm.h
+++ b/linux/sys/comm.h
@@ -23,6 +23,9 @@ struct TTY:
     ~TTY() {
         close(fd);
     }
+    bool full() override {
+        return tx.full();
+    }
     using Sink::push;
     void push(Buffer<uint8_t> &&b) override {
         tx.push(std::move(b));
@@ -102,6 +105,9 @@ struct UDP:
     }
     ~UDP() {
         close(fd);
+    }
+    bool full() override {
+        return tx.full();
     }
     using Sink::push;
     void push(Buffer<uint8_t> &&b) override {

--- a/stm/can.cpp
+++ b/stm/can.cpp
@@ -123,6 +123,9 @@ HW::~HW() {
                                    CAN_IT_TX_MAILBOX_EMPTY);
     HAL_CAN_Stop(&handle);
 }
+bool HW::full() {
+    return tx.q.full();
+}
 void HW::push(Message &&msg) {
     if (HAL_CAN_GetTxMailboxesFreeLevel(&handle)) {
         _start(&handle, std::move(msg));

--- a/stm/i2c.cpp
+++ b/stm/i2c.cpp
@@ -110,6 +110,10 @@ void _complete(I2C_HandleTypeDef *handle) {
     poll(i2c);
 }
 
+bool HW::full() {
+    return q.full();
+}
+
 void HW::push(Request &&rq) {
     switch (rq.opts.type) {
         case Request::Type::SLAVE_WRITE:

--- a/stm/spi.cpp
+++ b/stm/spi.cpp
@@ -95,6 +95,10 @@ void _complete(SPI_HandleTypeDef *handle) {
     poll(spi);
 }
 
+bool HW::full() {
+    return q.full();
+}
+
 void HW::push(Request &&rq) {
     q.push(std::move(rq));
     poll(this);

--- a/stm/sys/can.h
+++ b/stm/sys/can.h
@@ -16,6 +16,7 @@ struct HW : public CAN {
     };
     HW(const Config &);
     ~HW();
+    bool full() override;
     void push(Message &&) override;
     using Sink::push;
     Message pop() override { return rx.pop(); };

--- a/stm/sys/i2c.h
+++ b/stm/sys/i2c.h
@@ -79,6 +79,8 @@ struct HW : public Sink<Request> {
     };
     /** init peripheral with given Conf */
     HW(const Conf &conf);
+    /** no need to call this before pushing SLAVE requests */
+    bool full() override;
     void push(Request &&rq) override;
     using Sink<Request>::push;
     void irqEvHandler();

--- a/stm/sys/spi.h
+++ b/stm/sys/spi.h
@@ -84,6 +84,7 @@ struct HW : public Sink<Request> {
     };
     /** init peripheral with given Conf */
     HW(const Conf &conf);
+    bool full() override;
     void push(Request &&rq) override;
     using Sink<Request>::push;
     void irqHandler();

--- a/stm/sys/uart.h
+++ b/stm/sys/uart.h
@@ -11,7 +11,7 @@
 #include "registry.h"
 
 namespace UART {
-/** Character Buffer Sink & Source wrapping UART Peripheral 
+/** Character Buffer Sink & Source wrapping UART Peripheral
  *
  * \dot
  * digraph UART_SINK_SOURCE {
@@ -46,6 +46,7 @@ struct HW : public Sink<Buffer<uint8_t>>, public Source<Buffer<uint8_t>> {
     HW(const Default &conf);
     /** constructor with manually specifiable settings */
     HW(const Manual &conf);
+    bool full() override;
     /** push bytebuffer into sending queue */
     void push(Buffer<uint8_t> &&tx) override;
     using Sink<Buffer<uint8_t>>::push;

--- a/stm/uart.cpp
+++ b/stm/uart.cpp
@@ -194,6 +194,9 @@ void HW::irqHandler() {
     /* luckily we only ever use this one type of reception */
     handle.ReceptionType = HAL_UART_RECEPTION_TOIDLE;
 }
+bool HW::full() {
+    return tx.q.full();
+}
 void HW::push(Buffer<uint8_t> &&b) {
     tx.q.push(std::move(b));
     poll(this);

--- a/tests/min.cpp
+++ b/tests/min.cpp
@@ -4,6 +4,9 @@
 #include <doctest/doctest.h>
 
 struct Printer : Sink<Buffer<uint8_t>> {
+    bool full() override {
+        return false;
+    }
     void push(Buffer<uint8_t> &&b) override {
         printf("%.*s\n", b.len, b.buf);
     }

--- a/utils/queue.h
+++ b/utils/queue.h
@@ -80,7 +80,7 @@ public:
         return q.len == 0;
     }
     /** return true if queue is full */
-    bool full() {
+    bool full() override {
         return q.len == q.size;
     }
     /** return element at idx */


### PR DESCRIPTION
this matches the impedance to the generic Source type. Usage will also follow that of Source. It is never correct to call `push` unconditionally:
```cpp
if (!sink.full()) { sink.push(data); }
else { warn("sink was full"); }
```
if you do not care whether you'll successfully push data out, use `trypush`

this commit also implements the methods throughout tool-libs

**NOTE**: 
this is just one possibility of fixing the underlying issue: `push` doesn't check for space, and gives no feedback. This issue is still present with these patches, however, now the user can work around it by checking for space themselves.

another option would be to change the method to
```cpp
bool push(T)
```
and make sure implementations always check for space before accepting data. This however  doesn't really work for the 'moving' data version of the method: data gets moved in, if the space-check fails it gets dropped, and gets lost, without 'userspace' being able to recover the data.

This suggests that the `full()` method is needed after all. The remaining question would then only be if it wouldn't be smart to change the semantics of `push` so that it never pushes in an unchecked manner, even if the user doesn't check themselves. What to do upon failure though?

Having more ergonomic Optionals and Error handling would make it easier to bubble up all errors to the user.